### PR TITLE
Changing R default contrast setting into orthogonal contrasts #40

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
    
+- `anova_test()` function: Changing R default contrast setting (`contr.treatment`) into orthogonal contrasts (`contr.sum`) to have comparable results to SPSS when users define the model using formula (@benediktclaus, [#40](https://github.com/kassambara/rstatix/issues/40)).
 - Now, the option `type = "quantile"` of `get_summary_stats()` works properly (@Boyoron, [#39](https://github.com/kassambara/rstatix/issues/39)).
 
 

--- a/R/anova_test.R
+++ b/R/anova_test.R
@@ -448,7 +448,10 @@ fit_lm <- function(.args){
   .args <- remove_missing_values_in_data(.args)
   lm_data <- droplevels(.args$data)
   lm_formula <- .args$formula
-  stats::lm(lm_formula, lm_data)
+  opt <- options( "contrasts" = c( "contr.sum", "contr.poly" ) )
+  results <- stats::lm(lm_formula, lm_data)
+  options(opt)
+  results
 }
 
 # Compute the different types of ANOVA -----------------------------


### PR DESCRIPTION
`anova_test()` function: Changing R default contrast setting (`contr.treatment`) into orthogonal contrasts (`contr.sum`) to have comparable results to SPSS when users define the model using formula (@benediktclaus, [#40](https://github.com/kassambara/rstatix/issues/40))