### PR TITLE
+ is not defined for piping data

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -165,7 +165,7 @@ These functions are internally used in the `rstatix` and in the `ggpubr` R packa
    
 ### Others
    
-- `doo()`: alternative to dplyr::do for doing anything. Technically it uses `nest() + mutate() + map()` to apply arbitrary computation to a grouped data frame.
+- `doo()`: alternative to dplyr::do for doing anything. Technically it uses `nest(...) %>% mutate(...) %>% map(...)` to apply arbitrary computation to a grouped data frame.
 - `sample_n_by()`: sample n rows by group from a table
 - `convert_as_factor(), set_ref_level(), reorder_levels()`: Provides pipe-friendly functions to convert simultaneously multiple variables into a factor variable.
 - `make_clean_names()`: Pipe-friendly function to make syntactically valid column names (for input data frame) or names (for input vector).


### PR DESCRIPTION
While it can be inferred that the use of `+` is informal, we may as well use the more formal and less confusing chaining operator `%>%`, which is also what's used in the source code for `doo()`