### PR TITLE
Added bootstrap options parallel and ncpus

### DIFF
--- a/R/kruskal_effesize.R
+++ b/R/kruskal_effesize.R
@@ -46,19 +46,19 @@ NULL
 #'   group_by(supp) %>%
 #'   kruskal_effsize(len ~ dose)
 #' @export
-kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000){
+kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, parallel = "multicore", ncpus = parallel::detectCores()){
   args <- as.list(environment()) %>%
     .add_item(method = "kruskal_effsize")
   data %>%
     doo(
       .kruskal_effsize, formula, ci = ci, conf.level = conf.level,
-      ci.type = ci.type, nboot = nboot
+      ci.type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
     ) %>%
     set_attrs(args = args) %>%
     add_class(c("rstatix_test", "kruskal_effsize"))
 }
 
-.kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000){
+.kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, parallel = "multicore", ncpus = parallel::detectCores()){
   results <- eta_squared_h(data, formula)
   # Confidence interval of the effect size r
   if (ci == TRUE) {
@@ -67,7 +67,7 @@ kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.ty
     }
     CI <- get_boot_ci(
       data, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot
+      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
     )
     results <- results %>%
       add_columns(conf.low = CI[1], conf.high = CI[2], .after = "effsize")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -701,10 +701,10 @@ get_pairwise_comparison_methods <- function(){
 }
 
 # Bootstrap confidence intervals -------------------------
-get_boot_ci <- function(data, stat.func, conf.level = 0.95, type = "perc", nboot = 500){
+get_boot_ci <- function(data, stat.func, conf.level = 0.95, type = "perc", nboot = 500, parallel = "multicore", ncpus = parallel::detectCores()){
   required_package("boot")
-  Boot = boot::boot(data, stat.func, R = nboot)
-  BCI = boot::boot.ci(Boot, conf = conf.level, type = type, parallel = "multicore")
+  Boot = boot::boot(data, stat.func, R = nboot, parallel = parallel, ncpus = ncpus)
+  BCI = boot::boot.ci(Boot, conf = conf.level, type = type)
   type <- switch(
     type, norm = "normal", perc = "percent",
     basic = "basic", bca = "bca", stud = "student", type

--- a/R/wilcox_effsize.R
+++ b/R/wilcox_effsize.R
@@ -29,6 +29,9 @@ NULL
 #'@param ci.type The type of confidence interval to use. Can be any of "norm",
 #'  "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.
 #'@param nboot The number of replications to use for bootstrap.
+#'@param parallel The type of parallel operation to be used (if any) (Default: "multicore").
+#'@param ncpus The number of processes to be used in parallel operation:
+#'   typically one would chose this to the number of available CPUs (Default: parallel::detectCores()).
 #'@param ... Additional arguments passed to the functions
 #'  \code{coin::wilcoxsign_test()} (case of one- or paired-samples test) or
 #'  \code{coin::wilcox_test()} (case of independent two-samples test).
@@ -68,7 +71,7 @@ NULL
 wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
                                 paired = FALSE, alternative = "two.sided",
                                 mu = 0, ci = FALSE, conf.level = 0.95, ci.type = "perc",
-                                nboot = 1000,  ...){
+                                nboot = 1000,  parallel = "multicore", ncpus = parallel::detectCores(), ...){
 
   env <- as.list(environment())
   args <- env %>% .add_item(method = "wilcox_effsize")
@@ -100,7 +103,7 @@ wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
 
 # Wilcoxon test using coin R package; returns effect size
 coin.wilcox.test <- function(x, y = NULL, mu = 0, paired = FALSE, alternative = c("two.sided", "less", "greater"),
-                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...){
+                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, parallel = "multicore", ncpus = parallel::detectCores(), ...){
   required_package("coin")
 
   alternative <- match.arg(alternative)
@@ -156,7 +159,7 @@ coin.wilcox.test <- function(x, y = NULL, mu = 0, paired = FALSE, alternative = 
     }
     CI <- get_boot_ci(
       data, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot
+      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
       )
     results <- results %>% mutate(conf.low = CI[1], conf.high = CI[2])
   }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -125,3 +125,4 @@ Ss'
 tidyverse
 tidyverse'
 Manova
+detectCores

--- a/man/kruskal_effsize.Rd
+++ b/man/kruskal_effsize.Rd
@@ -10,7 +10,9 @@ kruskal_effsize(
   ci = FALSE,
   conf.level = 0.95,
   ci.type = "perc",
-  nboot = 1000
+  nboot = 1000,
+  parallel = "multicore",
+  ncpus = parallel::detectCores()
 )
 }
 \arguments{
@@ -29,6 +31,11 @@ one or multiple levels giving the corresponding groups. For example,
 "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.}
 
 \item{nboot}{The number of replications to use for bootstrap.}
+
+\item{parallel}{The type of parallel operation to be used (if any) (Default: "multicore").}
+
+\item{ncpus}{The number of processes to be used in parallel operation:
+typically one would chose this to the number of available CPUs (Default: parallel::detectCores()).}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/man/wilcox_effsize.Rd
+++ b/man/wilcox_effsize.Rd
@@ -16,6 +16,8 @@ wilcox_effsize(
   conf.level = 0.95,
   ci.type = "perc",
   nboot = 1000,
+  parallel = "multicore",
+  ncpus = parallel::detectCores(),
   ...
 )
 }
@@ -57,6 +59,11 @@ hypothesis.}
 "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.}
 
 \item{nboot}{The number of replications to use for bootstrap.}
+
+\item{parallel}{The type of parallel operation to be used (if any) (Default: "multicore").}
+
+\item{ncpus}{The number of processes to be used in parallel operation:
+typically one would chose this to the number of available CPUs (Default: parallel::detectCores()).}
 
 \item{...}{Additional arguments passed to the functions
 \code{coin::wilcoxsign_test()} (case of one- or paired-samples test) or


### PR DESCRIPTION
Inside the function `get_boot_ci` the `boot::boot.ci` had the parallel option, which is wrong as it should be set for `boot::boot`.

The params `parallel` and `ncpus` can now also be set with when using `wilcox_effsize` or `kruskal_effsize`. Updated documentation accordingly.  