### PR TITLE
Update utilities.R stat_pvalue_manual Positions on the plot

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -271,7 +271,12 @@ get_levels <- function(data, group){
     return(data)
   group.values <- data %>% pull(group.col)
   if(!is.factor(group.values))
-    group.values <- as.factor(group.values)
+    # group.values <- as.factor(group.values) # conflict with ggpubr .check_data
+    if(is.character(group.values))
+      # If not factor, group (x) elements on the plot appear in the same order as in the data (ggpubr::.check_data)
+      #here we maintain the same order
+      group.values <- factor(group.values, levels = unique(group.values))
+  group.values <- as.factor(group.values)
   if(!is.null(ref.group)){
     if(ref.group != "")
       group.values <- stats::relevel(group.values, ref.group)


### PR DESCRIPTION
proposition to resolve the conflict between ggpubr plot and rstatix stat table x_y positions

the Anomalie (reproducible example)

library(ggpubr)
library(rstatix)

data2=data.frame(id =1:15 ,group=c(rep("C",5),rep("B",5),rep("A",5)),score=c(rnorm(5,0),rnorm(5,0.5),rnorm(5,2)))

head(data2)

res.kruskal = kruskal_test(data2, formula = score ~ group)
pwc = dunn_test(data2, formula = score ~ group, p.adjust.method = "BH")
pwc = pwc %>% add_xy_position(x = "group")
p <- ggboxplot(data2, x = "group", y = "score",
          color = "group", palette = "jco",
          add = "jitter",
          title=paste("boxplot"))
y = stat_pvalue_manual(pwc, hide.ns = TRUE)

lab= labs(
    subtitle = get_test_label(res.kruskal, detailed = FALSE),
    caption = get_pwc_label(pwc)
  )
print(p+y+lab)

pwc