### PR TITLE
Fix issue #169: Grouping variable is converted from factor to character in emmeans_test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     dplyr (>= 0.7.1),
     magrittr,
     corrplot,
-    tidyselect (>= 1.0.0),
+    tidyselect (>= 1.2.0),
     car,
     generics (>= 0.0.2)
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,11 +6,12 @@
    
 ## Minor changes
 
-- fix warning in `emmeans_test()`:  "Use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0."
-
+- Required `tidyselect` versions is `>= 1.2.0`
 ## Bug fixes
-
    
+- `emmeans_test()`: restoring grouping variable class (`factor`) in the final results `emmeans_test()` (#169)
+- Fix warning in `emmeans_test()`:  "Use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0."
+  
    
 # rstatix 0.7.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
    
 ## Minor changes
 
+- fix warning in `emmeans_test()`:  "Use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0."
+
 ## Bug fixes
 
    

--- a/R/emmeans_test.R
+++ b/R/emmeans_test.R
@@ -150,6 +150,20 @@ pairwise_emmeans_test <- function(res.emmeans, grouping.vars = NULL, method = "p
       mutate(p.adj = p.adjusted) %>%
       add_significance("p.adj")
 
+  # Homogenize variable classes between res.emmeans and comparisons
+  # because: tidy() is converting factor to character -> so restoring back factors
+    res.emmeans.tbl <- tibble::as_tibble(res.emmeans)
+    variables <- intersect(colnames(res.emmeans.tbl), colnames(comparisons))
+    for(variable in variables){
+      if(is.factor(res.emmeans.tbl[[variable]])){
+        comparisons[[variable]] <- factor(
+          comparisons[[variable]],
+          levels = levels(res.emmeans.tbl[[variable]])
+          )
+      }
+    }
+    comparisons <- base::droplevels(comparisons)
+
   comparisons %>%
     dplyr::arrange(!!!syms(grouping.vars))
 }

--- a/R/emmeans_test.R
+++ b/R/emmeans_test.R
@@ -98,7 +98,7 @@ emmeans_test <- function(data, formula, covariate = NULL, ref.group = NULL,
   res.emmeans <- res.emmeans %>%
     tibble::as_tibble() %>%
     dplyr::arrange(!!!syms(grouping.vars)) %>%
-    dplyr::rename(se = .data$SE, conf.low = .data$lower.CL, conf.high = .data$upper.CL) %>%
+    dplyr::rename(se = "SE", conf.low = "lower.CL", conf.high = "upper.CL") %>%
     mutate(method = "Emmeans test")
 
   if(!detailed){
@@ -135,7 +135,7 @@ pairwise_emmeans_test <- function(res.emmeans, grouping.vars = NULL, method = "p
   comparisons <- tidy(comparisons, conf.int = TRUE, conf.level = conf.level)
   comparisons <- comparisons %>%
     tidyr::separate(col = "contrast", into = c("group1", "group2"), sep = "-") %>%
-    dplyr::rename(se = .data$std.error, p = .data$p.value) %>%
+    dplyr::rename(se = "std.error", p = "p.value") %>%
     dplyr::select(!!!syms(grouping.vars), everything())
 
     # Adjust the pvalue. We don't want to use adjust_pvalue here, because

--- a/man/df_unite.Rd
+++ b/man/df_unite.Rd
@@ -31,7 +31,7 @@ commas.}
 
 \item{remove}{If \code{TRUE}, remove input columns from output data frame.}
 
-\item{na.rm}{If \code{TRUE}, missing values will be remove prior to uniting
+\item{na.rm}{If \code{TRUE}, missing values will be removed prior to uniting
 each value.}
 }
 \description{

--- a/tests/testthat/test-emmeans_test.R
+++ b/tests/testthat/test-emmeans_test.R
@@ -1,0 +1,57 @@
+
+test_that("emmeans_test works", {
+  # Data preparation
+  df <- ToothGrowth
+  df$dose <- as.factor(df$dose)
+  # Pairwise comparisons
+  comparisons <- df %>%
+    group_by(supp) %>%
+    emmeans_test(len ~ dose, p.adjust.method = "bonferroni") %>%
+    as.data.frame(stringsAsFactors = FALSE)
+  attributes(comparisons) <- list(
+    names = colnames(comparisons),
+    row.names = row.names(comparisons),
+    class = "data.frame"
+  )
+  # raw emmeans output
+  res_emmeans <- attr(res, "emmeans") %>%
+    as.data.frame(stringsAsFactors = FALSE)
+  attributes(res_emmeans) <- list(
+    names = colnames(res_emmeans),
+    row.names = row.names(res_emmeans),
+    class = "data.frame"
+  )
+
+  # Expected values
+  expected_comparisons <- tibble::tribble(
+     ~supp,  ~term,  ~.y., ~group1, ~group2, ~df,        ~statistic,                   ~p,               ~p.adj, ~p.adj.signif,
+      "OJ", "dose", "len",   "0.5",     "1",  54, -5.83122150109434, 3.17564054631384e-07, 9.52692163894153e-07,        "****",
+      "OJ", "dose", "len",   "0.5",     "2",  54,  -7.9001659830032, 1.42971201237994e-10, 4.28913603713983e-10,        "****",
+      "OJ", "dose", "len",     "1",     "2",  54, -2.06894448190887,   0.0433521450968846,    0.130056435290654,          "ns",
+      "VC", "dose", "len",   "0.5",     "1",  54, -5.41250654642231, 1.46293144787886e-06, 4.38879434363658e-06,        "****",
+      "VC", "dose", "len",   "0.5",     "2",  54, -11.1821523188884, 1.13067681037436e-15, 3.39203043112308e-15,        "****",
+      "VC", "dose", "len",     "1",     "2",  54,  -5.7696457724661, 3.98114048489776e-07, 1.19434214546933e-06,        "****"
+     ) %>%
+    dplyr::mutate(supp = factor(supp, levels =  c("OJ", "VC"))) %>%
+    data.frame(stringsAsFactors = FALSE,  row.names = as.character(1:6))
+
+  expected_emmeans <- tibble::tribble(
+     ~supp, ~dose, ~emmean,              ~se, ~df,        ~conf.low,       ~conf.high,        ~method,
+      "OJ", "0.5",   13.23, 1.14835308804166,  54, 10.9276906782585, 15.5323093217415, "Emmeans test",
+      "OJ",   "1",    22.7, 1.14835308804166,  54, 20.3976906782585, 25.0023093217415, "Emmeans test",
+      "OJ",   "2",   26.06, 1.14835308804166,  54, 23.7576906782585, 28.3623093217415, "Emmeans test",
+      "VC", "0.5",    7.98, 1.14835308804166,  54, 5.67769067825848, 10.2823093217415, "Emmeans test",
+      "VC",   "1",   16.77, 1.14835308804166,  54, 14.4676906782585, 19.0723093217415, "Emmeans test",
+      "VC",   "2",   26.14, 1.14835308804166,  54, 23.8376906782585, 28.4423093217415, "Emmeans test"
+     ) %>%
+    dplyr::mutate(
+      supp = factor(supp, levels =  c("OJ", "VC")),
+      dose = factor(dose, levels = c("0.5", "1", "2"))
+      ) %>%
+    data.frame(stringsAsFactors = FALSE, row.names = as.character(1:6))
+
+  # Make sure that he class of grouping variable is preserved
+  expect_equal(class(comparisons$supp), "factor")
+  expect_equal(comparisons, expected_comparisons, tolerance = 1e-4)
+  expect_equal(res_emmeans, expected_emmeans, tolerance = 1e-4)
+})

--- a/tests/testthat/test-emmeans_test.R
+++ b/tests/testthat/test-emmeans_test.R
@@ -8,14 +8,15 @@ test_that("emmeans_test works", {
     group_by(supp) %>%
     emmeans_test(len ~ dose, p.adjust.method = "bonferroni") %>%
     as.data.frame(stringsAsFactors = FALSE)
+  # raw emmeans output
+  res_emmeans <- attr(comparisons, "emmeans") %>%
+    as.data.frame(stringsAsFactors = FALSE)
+
   attributes(comparisons) <- list(
     names = colnames(comparisons),
     row.names = row.names(comparisons),
     class = "data.frame"
   )
-  # raw emmeans output
-  res_emmeans <- attr(res, "emmeans") %>%
-    as.data.frame(stringsAsFactors = FALSE)
   attributes(res_emmeans) <- list(
     names = colnames(res_emmeans),
     row.names = row.names(res_emmeans),


### PR DESCRIPTION
## Main changes

- [Restoring back factor class after broom::tidy()](https://github.com/kassambara/rstatix/commit/b1421bf5f91a222ea0eaea804dfd6c266bd8cc42)
- [emmeans_test: unit test added](https://github.com/kassambara/rstatix/commit/4ae32d358988f655552ac6c3bdd00ddae7134a16)
- fix ggpubr issue: https://github.com/kassambara/ggpubr/issues/386