### PR TITLE
fix: correct sample size n reporting in kruskal_test with missing values

### DIFF
--- a/R/kruskal_test.R
+++ b/R/kruskal_test.R
@@ -55,8 +55,11 @@ kruskal_test <- function(data, formula, ...){
   outcome <- get_formula_left_hand_side(formula)
   group <- get_formula_right_hand_side(formula)
   term <- statistic <- p <- df <- method <- NULL
-  stats::kruskal.test(formula, data = data, ...) %>%
+  
+  mf <- stats::model.frame(formula, data = data, ...)
+  
+  stats::kruskal.test(formula, data = mf) %>%
     as_tidy_stat() %>%
     select(statistic, df, p, method) %>%
-    add_column(.y. = outcome, n = nrow(data), .before = "statistic")
+    add_column(.y. = outcome, n = nrow(mf), .before = "statistic")
 }

--- a/tests/testthat/test-kruskal_test.R
+++ b/tests/testthat/test-kruskal_test.R
@@ -1,0 +1,16 @@
+context("Testing kruskal_test and kruskal_effsize missing value handling")
+
+test_that("kruskal_test reports correct sample size 'n' when handling missing values", {  
+  set.seed(123)
+  test_df <- data.frame(
+    group = factor(rep(c(NA, "A", "B", "C"), each = 10)),
+    value = c(rnorm(35), rep(NA, 5))
+  )
+  res_default <- kruskal_test(test_df, value ~ group)
+  expect_equal(res_default$n, 25)
+  res_explicit <- kruskal_test(test_df, value ~ group, na.action = stats::na.omit)
+  expect_equal(res_explicit$n, 25)
+  pristine_df <- na.omit(test_df)
+  res_pristine <- kruskal_test(pristine_df, value ~ group)
+  expect_equal(res_pristine$n, 25)
+})


### PR DESCRIPTION
### Description
This PR resolves an issue where `rstatix::kruskal_test()` and `rstatix::kruskal_effsize()` report an incorrect sample size (`n`) in their output tibbles when the input dataset contains missing values (`NA`) in the dependent variable. 

### Root Cause
Previously, `.kruskal_test` hardcoded `n = nrow(data)`. If the grouping factor was complete but the numeric response variable contained `NA`s, the returned `n` reflected the raw row count before `stats::kruskal.test` dropped missing values via `na.action`. While the underlying test statistic ($H$) was calculated accurately on complete cases, the reported sample size was falsely inflated and used by `kruskal_effesize`.

### Solution
Modified `.kruskal_test()` to generate a processed model frame using `stats::model.frame(formula, data = data, ...)` prior to running the test. This natively adheres to the active `na.action` setting (or manual inline overrides passed through the ellipsis) and ensures `nrow(mf)` captures the exact number of observations evaluated.

### Minimal Reproducible Example (Before vs After)

```r
library(rstatix)
set.seed(123)
test_df <- data.frame(
  group = factor(rep(c(NA, "A", "B", "C"), each = 10)),
  value = c(rnorm(35), rep(NA, 5))
)

rstatix::kruskal_test(test_df, value ~ group)
```

**Before this PR:**
Returned `n = 40` (Incorrect).

**After this PR:**
Returned `n = 25` (Correct).

### Checklist
- [x] Changes manual-tested locally using `devtools::load_all()`
- [x] Added unit tests tracking `kruskal_test` handling of missing values to `tests/testthat/test-kruskal_test.R`