### PR TITLE
Fix R-devel CI: make paired wilcox_test assertion version-robust

### DIFF
--- a/tests/testthat/test-wilcox_test.R
+++ b/tests/testthat/test-wilcox_test.R
@@ -32,11 +32,17 @@ test_that("Checking two-sample paired test", {
   expect_equal(res$group2, "VC")
   expect_equal(res$n1, 30)
   expect_equal(res$n2, 30)
-  # Accept either 350/0.00431 (legacy) or 369/0.00383 (R-devel)
-  expect_true(as.numeric(res$statistic) %in% c(350, 369),
-              info = paste("Observed statistic =", as.numeric(res$statistic)))
-  expect_true(signif(res$p, 3) %in% c(0.00431, 0.00383),
-              info = paste("Observed p =", signif(res$p, 3)))
+  # Compare against base R computed the same way so the test tracks the active
+  # R version instead of chasing hard-coded values: wilcox.test's paired V
+  # statistic and p-value shifted on R-devel (350/0.00431 on R <= 4.5,
+  # 369/0.00381 on devel).
+  ref <- suppressWarnings(stats::wilcox.test(
+    ToothGrowth$len[ToothGrowth$supp == "OJ"],
+    ToothGrowth$len[ToothGrowth$supp == "VC"],
+    paired = TRUE
+  ))
+  expect_equal(as.numeric(res$statistic), as.numeric(ref$statistic))
+  expect_equal(res$p, ref$p.value, tolerance = 1e-3)
 })
 
 test_that("Checking pairwise comparisons", {


### PR DESCRIPTION
## Problem
`R-CMD-check` on `master` is red on **ubuntu-latest (R-devel)** (other 4 platforms green):
[run 28230254272](https://github.com/kassambara/rstatix/actions/runs/28230254272/job/83631997312).

The only build-failing item is one test:
```
── Failure ('test-wilcox_test.R:38:3'): Checking two-sample paired test ──
Expected `signif(res$p, 3) %in% c(0.00431, 0.00383)` to be TRUE.
Observed p = 0.00381
```
R-devel's `stats::wilcox.test` produces a slightly different paired V statistic and p-value
(369 / 0.00381) than R ≤ 4.5 (350 / 0.00431). The test hard-coded the expected values and had
already been patched once for an earlier drift — a fragile, version-chasing pattern.

## Fix
Compare rstatix's result against base R `wilcox.test` **computed the same way, in the test**, so the
assertion tracks whatever the active R version computes instead of magic numbers:
```r
ref <- suppressWarnings(stats::wilcox.test(
  ToothGrowth$len[ToothGrowth$supp == "OJ"],
  ToothGrowth$len[ToothGrowth$supp == "VC"], paired = TRUE))
expect_equal(as.numeric(res$statistic), as.numeric(ref$statistic))
expect_equal(res$p, ref$p.value, tolerance = 1e-3)
```
- **Test-only change — no package behavior changes** (nothing in `R/` touched).
- Still a real check: `ref` is computed independently from the raw data, so a genuine rstatix
  regression (wrong pairing/groups/stat) would still fail. Statistic is matched exactly; p within tol.
- `suppressWarnings` keeps the existing ties/zeros warning count unchanged.

## Verification
`Rscript --vanilla -e 'devtools::test()'` (clean session, CI parity) → **FAIL 0 | PASS 132**.

## Note (out of scope, separate follow-up)
The run also shows 21 testthat **tidyselect deprecation warnings** (`expr_kind`/`call_kind` via
`dplyr::select`). These do not fail the build (the check reports `1 ERROR`, 0 WARNING) but should be
modernized in a separate PR before they become errors.
