### PR TITLE
Fix missing space in anova_test single-level-factor error message (#137)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Bug fixes
 
+- Fixed a missing space in the `anova_test()` error message for single-level factors (now reads "Variable x has only one level") ([#137](https://github.com/kassambara/rstatix/issues/137)).
+
 
 # rstatix 0.7.3
 

--- a/R/factorial_design.R
+++ b/R/factorial_design.R
@@ -243,7 +243,7 @@ assertthat_iv_has_enough_levels <- function(.args){
   for(.var in vars){
     n.levels <- unique(data[[.var]]) %>% length()
     if(n.levels == 1){
-      stop("Variable ", .var, "has only one level. ",
+      stop("Variable ", .var, " has only one level. ",
            "Remove it from the model.")
     }
   }

--- a/tests/testthat/test-anova_test.R
+++ b/tests/testthat/test-anova_test.R
@@ -95,3 +95,17 @@ test_that("Checking that get_anova_table performs auto sphericity correction", {
   expect_equal(gg$DFd, c(9, 15.09, 16.88))
   expect_equal(gg$p, c(2.28e-04, 2.79e-09, 1.12e-01))
 })
+
+test_that("anova_test gives a well-formed error for a single-level factor (#137)", {
+  d <- data.frame(id = factor(1:6), grp = factor(rep("a", 6)), score = c(1, 2, 3, 4, 5, 6))
+  expect_error(
+    anova_test(d, dv = score, wid = id, between = grp),
+    "has only one level"
+  )
+  # regression for the missing space (#137): must read "grp has", not "grphas"
+  msg <- tryCatch(
+    anova_test(d, dv = score, wid = id, between = grp),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(msg, "Variable grp has only one level")
+})


### PR DESCRIPTION
## Problem
When an independent variable passed to `anova_test()` has a single level, the error message was missing a space: `Variable xhas only one level.` (#137).

## Fix
Add the space in `assertthat_iv_has_enough_levels()` (`R/factorial_design.R`): now `Variable x has only one level.`

- **Message-only change** — no effect on any successful call; the code path only runs in the existing single-level error case.
- Regression test added (`test-anova_test.R`) asserting the corrected, well-formed message.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 134.

Fixes #137
