### PR TITLE
Update CRAN checks badge to badges.cranchecks.info (#174)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## Minor changes
 
+- Updated the CRAN checks badge in the README to the current `badges.cranchecks.info` endpoint (the old `cranchecks.info` badge no longer resolves) ([#174](https://github.com/kassambara/rstatix/issues/174)).
+
 ## Bug fixes
 
 - Fixed a missing space in the `anova_test()` error message for single-level factors (now reads "Variable x has only one level") ([#137](https://github.com/kassambara/rstatix/issues/137)).

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 [![R build status](https://github.com/kassambara/rstatix/workflows/R-CMD-check/badge.svg)](https://github.com/kassambara/rstatix/actions)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/rstatix)](https://cran.r-project.org/package=rstatix)
-[![CRAN Checks](https://cranchecks.info/badges/summary/rstatix)](https://cran.r-project.org/web/checks/check_results_rstatix.html)
+[![CRAN Checks](https://badges.cranchecks.info/summary/rstatix.svg)](https://cran.r-project.org/web/checks/check_results_rstatix.html)
 [![Downloads](https://cranlogs.r-pkg.org/badges/rstatix)](https://cran.r-project.org/package=rstatix)
 [![Total Downloads](https://cranlogs.r-pkg.org/badges/grand-total/rstatix?color=orange)](https://cran.r-project.org/package=rstatix)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 status](https://github.com/kassambara/rstatix/workflows/R-CMD-check/badge.svg)](https://github.com/kassambara/rstatix/actions)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/rstatix)](https://cran.r-project.org/package=rstatix)
 [![CRAN
-Checks](https://cranchecks.info/badges/summary/rstatix)](https://cran.r-project.org/web/checks/check_results_rstatix.html)
+Checks](https://badges.cranchecks.info/summary/rstatix.svg)](https://cran.r-project.org/web/checks/check_results_rstatix.html)
 [![Downloads](https://cranlogs.r-pkg.org/badges/rstatix)](https://cran.r-project.org/package=rstatix)
 [![Total
 Downloads](https://cranlogs.r-pkg.org/badges/grand-total/rstatix?color=orange)](https://cran.r-project.org/package=rstatix)


### PR DESCRIPTION
## Problem
The README CRAN-checks badge used `https://cranchecks.info/badges/summary/rstatix`, which no longer resolves (#174).

## Fix
Point it at the current canonical endpoint `https://badges.cranchecks.info/summary/rstatix.svg` (verified HTTP 200) in both `README.Rmd` and `README.md`.

- Docs-only; no R code, no tests.
- `README.md` was edited directly to match `README.Rmd` rather than re-rendering, to keep the diff to the badge line and avoid churning the `tools/README-*.png` figures.

Fixes #174
