### PR TITLE
Fix pairwise_binom_test_against_p() crash on an unnamed vector (#44)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- `pairwise_binom_test_against_p()` no longer errors on an unnamed `x`; groups are auto-labelled `grp1`, `grp2`, … (named/table input is unchanged) ([#44](https://github.com/kassambara/rstatix/issues/44)).
 - Fixed a missing space in the `anova_test()` error message for single-level factors (now reads "Variable x has only one level") ([#137](https://github.com/kassambara/rstatix/issues/137)).
 
 

--- a/R/binom_test.R
+++ b/R/binom_test.R
@@ -146,7 +146,7 @@ pairwise_binom_test_against_p <- function(x, p = rep(1/length(x), length(x)), p.
   }
   groups <- names(x)
   if(is.null(groups)) {
-    names(groups) <- paste0("grp", 1:length(x))
+    groups <- paste0("grp", seq_along(x))
   }
   if(inherits(x, "table")){
     x <- as.vector(x)

--- a/tests/testthat/test-binom_test.R
+++ b/tests/testthat/test-binom_test.R
@@ -1,0 +1,20 @@
+context("test-binom_test")
+
+test_that("pairwise_binom_test_against_p works with an unnamed vector (#44)", {
+  res <- pairwise_binom_test_against_p(c(20, 30, 50))
+  expect_s3_class(res, "rstatix_test")
+  expect_equal(nrow(res), 3)
+  expect_equal(res$group, c("grp1", "grp2", "grp3"))
+  expect_true(all(c("group", "p", "p.adj") %in% colnames(res)))
+})
+
+test_that("pairwise_binom_test_against_p preserves names for named/table input (no regression, #44)", {
+  named   <- pairwise_binom_test_against_p(c(a = 20, b = 30, c = 50))
+  unnamed <- pairwise_binom_test_against_p(c(20, 30, 50))
+  tbl     <- pairwise_binom_test_against_p(as.table(c(x = 20, y = 30, z = 50)))
+  expect_equal(named$group, c("a", "b", "c"))
+  expect_equal(tbl$group,   c("x", "y", "z"))
+  # only the group labels differ between named and unnamed; the statistics are identical
+  expect_equal(named$p, unnamed$p)
+  expect_equal(named$p.adj, unnamed$p.adj)
+})


### PR DESCRIPTION
## Problem
`pairwise_binom_test_against_p()` errored on an **unnamed** `x` (#44): `groups <- names(x)` is `NULL`, then `names(groups) <- paste0("grp", ...)` throws *"attempt to set an attribute on NULL"*.

## Fix
Assign the auto-labels directly inside the existing `if (is.null(groups))` branch:
```r
-    names(groups) <- paste0("grp", 1:length(x))
+    groups <- paste0("grp", seq_along(x))
```

## No regression (gated)
The change lives **only** in the `is.null(groups)` branch — when `x` is named (or a `table`), `groups <- names(x)` is taken and the new line never fires. Verified the **named-input result is byte-identical** to before, and table input is unchanged. A fresh adversarial review confirmed no regressions across edge cases (length-2, partial names, table input).

## Tests
New `tests/testthat/test-binom_test.R`: (a) unnamed `c(20,30,50)` → `grp1/grp2/grp3`, no error; (b) named/table labels preserved and stats identical to the unnamed call.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 142.

Fixes #44
