### PR TITLE
tukey_hsd(): respect conf.level for the ungrouped data-frame interface (#188)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- `tukey_hsd()` now respects `conf.level` (and other `TukeyHSD()` arguments) for the ungrouped data-frame interface; previously `...` was dropped so the confidence interval was always 95% ([#188](https://github.com/kassambara/rstatix/issues/188)).
 - `pairwise_binom_test_against_p()` no longer errors on an unnamed `x`; groups are auto-labelled `grp1`, `grp2`, … (named/table input is unchanged) ([#44](https://github.com/kassambara/rstatix/issues/44)).
 - Fixed a missing space in the `anova_test()` error message for single-level factors (now reads "Variable x has only one level") ([#137](https://github.com/kassambara/rstatix/issues/137)).
 

--- a/R/tukey_hsd.R
+++ b/R/tukey_hsd.R
@@ -90,7 +90,7 @@ tukey_hsd.data.frame <- function(x, formula, ...){
     return(results)
   }
 
-  tukey_hsd_core (x, formula) %>%
+  tukey_hsd_core (x, formula, ...) %>%
     set_attrs(args = args) %>%
     add_class(c("rstatix_test", "tukey_hsd"))
 }

--- a/tests/testthat/test-tukey_hsd.R
+++ b/tests/testthat/test-tukey_hsd.R
@@ -1,0 +1,21 @@
+context("test-tukey_hsd")
+
+test_that("tukey_hsd forwards conf.level for ungrouped data (#188)", {
+  d <- ToothGrowth; d$dose <- factor(d$dose)
+  a95 <- d %>% tukey_hsd(len ~ dose, conf.level = 0.95)
+  a99 <- d %>% tukey_hsd(len ~ dose, conf.level = 0.99)
+  # a 99% CI must be wider than the 95% CI (lower bound smaller, upper bound larger)
+  expect_true(all(a99$conf.low  < a95$conf.low))
+  expect_true(all(a99$conf.high > a95$conf.high))
+  # the (Tukey-adjusted) p-values do not depend on conf.level
+  expect_equal(a95$p.adj, a99$p.adj)
+})
+
+test_that("tukey_hsd default conf.level (0.95) is unchanged (no regression, #188)", {
+  d <- ToothGrowth; d$dose <- factor(d$dose)
+  res   <- d %>% tukey_hsd(len ~ dose)                 # default
+  res95 <- d %>% tukey_hsd(len ~ dose, conf.level = 0.95)
+  expect_equal(res$conf.low,  res95$conf.low)
+  expect_equal(res$conf.high, res95$conf.high)
+  expect_equal(res$p.adj,     res95$p.adj)
+})


### PR DESCRIPTION
## Problem
`tukey_hsd()` ignored `conf.level` for the ungrouped data-frame interface (#188): the confidence interval was always 95% regardless of the value passed.

## Root cause
In `tukey_hsd.data.frame()` the ungrouped branch called `tukey_hsd_core(x, formula)` **without forwarding `...`**, so `conf.level` never reached `stats::TukeyHSD()`. (The grouped branch already forwarded `...` via `doo()`.)

## Fix
```r
-  tukey_hsd_core (x, formula) %>%
+  tukey_hsd_core (x, formula, ...) %>%
```

## No regression
- The **default** output (no `conf.level`) is **byte-identical** to before (verified): forwarding an empty `...` changes nothing.
- `p.adj` is unaffected by `conf.level` (Tukey-adjusted p).
- Grouped / `aov` / `lm` / `default` methods, two-way formulas, and `which=` are unaffected (adversarially reviewed).

## Tests
New `tests/testthat/test-tukey_hsd.R`: (a) `conf.level = 0.99` gives wider CIs than `0.95`; (b) default == explicit 0.95 (no regression). Relational assertions only — no hard-coded version-fragile TukeyHSD numerics.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 148.

Fixes #188
