### PR TITLE
anova_test(): return both pes and ges when effect.size = c('pes','ges') (#180)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- `anova_test()` / `anova_summary()` now return **both** effect sizes when `effect.size = c("pes", "ges")` is requested; previously only partial eta squared was kept ([#180](https://github.com/kassambara/rstatix/issues/180)).
 - `tukey_hsd()` now respects `conf.level` (and other `TukeyHSD()` arguments) for the ungrouped data-frame interface; previously `...` was dropped so the confidence interval was always 95% ([#188](https://github.com/kassambara/rstatix/issues/188)).
 - `pairwise_binom_test_against_p()` no longer errors on an unnamed `x`; groups are auto-labelled `grp1`, `grp2`, … (named/table input is unchanged) ([#44](https://github.com/kassambara/rstatix/issues/44)).
 - Fixed a missing space in the `anova_test()` error message for single-level factors (now reads "Variable x has only one level") ([#137](https://github.com/kassambara/rstatix/issues/137)).

--- a/R/anova_summary.R
+++ b/R/anova_summary.R
@@ -283,7 +283,10 @@ add_anova_effect_size <- function(res.anova.summary, effect.size = "ges",  obser
     res.anova.summary <- res.anova.summary %>%
       add_partial_eta_squared()
   }
-  else {
+  # Compute ges whenever it is requested, and also when neither is explicitly
+  # "pes" only (preserving the historical ges default for "ges"/unspecified
+  # values). This lets effect.size = c("pes", "ges") return BOTH columns (#180).
+  if(("ges" %in% effect.size) || !("pes" %in% effect.size)){
     res.anova.summary <- res.anova.summary %>%
       add_generalized_eta_squared(observed)
   }

--- a/tests/testthat/test-anova_test.R
+++ b/tests/testthat/test-anova_test.R
@@ -109,3 +109,18 @@ test_that("anova_test gives a well-formed error for a single-level factor (#137)
   )
   expect_match(msg, "Variable grp has only one level")
 })
+
+test_that("anova_test effect.size = c('pes','ges') returns BOTH columns (#180)", {
+  both <- iris %>%
+    anova_test(Sepal.Length ~ Sepal.Width + Species, effect.size = c("pes", "ges")) %>%
+    get_anova_table()
+  expect_true(all(c("pes", "ges") %in% colnames(both)))
+  # both-call values match the standalone single-effect-size computations (no regression)
+  ges <- iris %>% anova_test(Sepal.Length ~ Sepal.Width + Species, effect.size = "ges") %>% get_anova_table()
+  pes <- iris %>% anova_test(Sepal.Length ~ Sepal.Width + Species, effect.size = "pes") %>% get_anova_table()
+  expect_equal(both$ges, ges$ges)
+  expect_equal(both$pes, pes$pes)
+  # single-effect-size output is unchanged: exactly one of the two columns
+  expect_false("pes" %in% colnames(ges))
+  expect_false("ges" %in% colnames(pes))
+})


### PR DESCRIPTION
## Problem
`anova_test(effect.size = c("pes", "ges"))` (and `anova_summary()`) returned **only** partial eta squared — generalized eta squared was dropped (#180).

## Root cause
`add_anova_effect_size()` used `if("pes" %in% effect.size){...} else {...ges...}`, so when both were requested the `if` fired and the ges `else` never ran.

## Fix
Compute ges whenever it's requested, and keep the historical ges default for `"ges"`/unspecified values:
```r
if("pes" %in% effect.size) { ...add_partial_eta_squared() }
if(("ges" %in% effect.size) || !("pes" %in% effect.size)) { ...add_generalized_eta_squared(observed) }
```

## No regression
- `effect.size = "ges"` (default) and `"pes"` outputs are **byte-identical** to before (verified).
- An invalid value still falls back to ges (preserved).
- `observed=` still applies only to ges. RM (within) designs return both columns. Adversarially reviewed: SAFE.

## Tests
`test-anova_test.R` (#180): both-call has `pes` + `ges` with values equal to the standalone calls; single-effect-size output unchanged. No hard-coded numerics.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 153.

Fixes #180
