### PR TITLE
kruskal_effsize(): clamp eta-squared to [0,1] and fix magnitude label (#217)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- `kruskal_effsize()` no longer reports a negative (degenerate) eta-squared as "large"; such a negligible effect is now labelled "small" (the magnitude was using the absolute value) ([#217](https://github.com/kassambara/rstatix/issues/217)).
 - `anova_test()` / `anova_summary()` now return **both** effect sizes when `effect.size = c("pes", "ges")` is requested; previously only partial eta squared was kept ([#180](https://github.com/kassambara/rstatix/issues/180)).
 - `tukey_hsd()` now respects `conf.level` (and other `TukeyHSD()` arguments) for the ungrouped data-frame interface; previously `...` was dropped so the confidence interval was always 95% ([#188](https://github.com/kassambara/rstatix/issues/188)).
 - `pairwise_binom_test_against_p()` no longer errors on an unnamed `x`; groups are auto-labelled `grp1`, `grp2`, … (named/table input is unchanged) ([#44](https://github.com/kassambara/rstatix/issues/44)).

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 ## Bug fixes
 
-- `kruskal_effsize()` no longer reports a negative (degenerate) eta-squared as "large"; such a negligible effect is now labelled "small" (the magnitude was using the absolute value) ([#217](https://github.com/kassambara/rstatix/issues/217)).
+- `kruskal_effsize()` now clamps the eta-squared effect size to its valid `[0, 1]` range, so a near-null effect no longer returns a negative value (the formula could yield a small negative for a tiny `H`); consequently it is correctly labelled "small" rather than "large" (the magnitude had used the absolute value) ([#217](https://github.com/kassambara/rstatix/issues/217)).
 - `anova_test()` / `anova_summary()` now return **both** effect sizes when `effect.size = c("pes", "ges")` is requested; previously only partial eta squared was kept ([#180](https://github.com/kassambara/rstatix/issues/180)).
 - `tukey_hsd()` now respects `conf.level` (and other `TukeyHSD()` arguments) for the ungrouped data-frame interface; previously `...` was dropped so the confidence interval was always 95% ([#188](https://github.com/kassambara/rstatix/issues/188)).
 - `pairwise_binom_test_against_p()` no longer errors on an unnamed `x`; groups are auto-labelled `grp1`, `grp2`, … (named/table input is unchanged) ([#44](https://github.com/kassambara/rstatix/issues/44)).

--- a/R/kruskal_effesize.R
+++ b/R/kruskal_effesize.R
@@ -82,6 +82,10 @@ eta_squared_h <- function(data, formula, subset = NULL, ...){
   nb.groups <- res.kw$df + 1
   nb.samples <- res.kw$n
   etasq <- (res.kw$statistic - nb.groups + 1) / (nb.samples - nb.groups)
+  # eta-squared is bounded in [0, 1]; the formula can yield a small negative
+  # value for a near-null effect (very small H). Clamp to the valid range, as
+  # the effectsize package does, so the reported effect size is never < 0 (#217).
+  etasq <- max(0, min(1, etasq))
   tibble(
     .y. = get_formula_left_hand_side(formula),
     n = nb.samples,

--- a/R/kruskal_effesize.R
+++ b/R/kruskal_effesize.R
@@ -93,7 +93,11 @@ eta_squared_h <- function(data, formula, subset = NULL, ...){
 get_eta_squared_magnitude <- function(d){
   magnitude.levels = c(0.06, 0.14, Inf)
   magnitude = c("small","moderate","large")
-  d.index <- findInterval(abs(d), magnitude.levels)+1
+  # eta-squared is non-negative; a (degenerate) negative value indicates a
+  # negligible effect, so it should map to the smallest bucket. Do NOT take
+  # abs(d) here, otherwise a negative effsize is mislabelled (e.g. -0.184 was
+  # reported as "large") (#217).
+  d.index <- findInterval(d, magnitude.levels)+1
   magnitude <- factor(magnitude[d.index], levels = magnitude, ordered = TRUE)
   magnitude
 }

--- a/R/kruskal_effesize.R
+++ b/R/kruskal_effesize.R
@@ -15,6 +15,11 @@ NULL
 #'  litterature are: \code{0.01- < 0.06} (small effect), \code{0.06 - < 0.14}
 #'  (moderate effect) and \code{>= 0.14} (large effect).
 #'
+#'  Note that \code{eta2[H]} is a bias-corrected estimator, so the raw formula can
+#'  return a small negative value for a near-null effect (very small \code{H}). In
+#'  that case the estimate is floored to 0, keeping the reported effect size within
+#'  its valid \code{[0, 1]} range.
+#'
 #' Confidence intervals are calculated by bootstap.
 #'
 #'@inheritParams wilcox_effsize
@@ -82,9 +87,9 @@ eta_squared_h <- function(data, formula, subset = NULL, ...){
   nb.groups <- res.kw$df + 1
   nb.samples <- res.kw$n
   etasq <- (res.kw$statistic - nb.groups + 1) / (nb.samples - nb.groups)
-  # eta-squared is bounded in [0, 1]; the formula can yield a small negative
-  # value for a near-null effect (very small H). Clamp to the valid range, as
-  # the effectsize package does, so the reported effect size is never < 0 (#217).
+  # eta2[H] is a bias-corrected estimator (like adjusted R-squared / omega-squared)
+  # and can be slightly negative for a near-null effect (small H). Floor it to the
+  # documented [0, 1] range so the reported effect size is never < 0 (#217).
   etasq <- max(0, min(1, etasq))
   tibble(
     .y. = get_formula_left_hand_side(formula),

--- a/man/kruskal_effsize.Rd
+++ b/man/kruskal_effsize.Rd
@@ -50,6 +50,11 @@ Compute the effect size for Kruskal-Wallis test as the eta
  litterature are: \code{0.01- < 0.06} (small effect), \code{0.06 - < 0.14}
  (moderate effect) and \code{>= 0.14} (large effect).
 
+ Note that \code{eta2[H]} is a bias-corrected estimator, so the raw formula can
+ return a small negative value for a near-null effect (very small \code{H}). In
+ that case the estimate is floored to 0, keeping the reported effect size within
+ its valid \code{[0, 1]} range.
+
 Confidence intervals are calculated by bootstap.
 }
 \examples{

--- a/tests/testthat/test-kruskal_effsize.R
+++ b/tests/testthat/test-kruskal_effsize.R
@@ -1,0 +1,17 @@
+context("test-kruskal_effsize")
+
+test_that("kruskal_effsize does not mislabel a negative eta-squared as 'large' (#217)", {
+  # identical, interleaved group profiles -> tiny H -> (degenerate) negative eta-squared
+  d <- data.frame(y = c(1, 2, 3, 1, 2, 3, 1, 2, 3),
+                  g = factor(rep(c("a", "b", "c"), each = 3)))
+  res <- suppressWarnings(kruskal_effsize(d, y ~ g))
+  expect_true(res$effsize < 0)                        # negative (negligible) effect size
+  expect_equal(as.character(res$magnitude), "small")  # must NOT be reported as 'large'
+})
+
+test_that("kruskal_effsize magnitude is unchanged for valid effect sizes (no regression, #217)", {
+  # ToothGrowth dose has a strong effect -> magnitude 'large' (unchanged behaviour)
+  res <- ToothGrowth %>% kruskal_effsize(len ~ dose)
+  expect_true(res$effsize > 0.14)
+  expect_equal(as.character(res$magnitude), "large")
+})

--- a/tests/testthat/test-kruskal_effsize.R
+++ b/tests/testthat/test-kruskal_effsize.R
@@ -1,12 +1,13 @@
 context("test-kruskal_effsize")
 
-test_that("kruskal_effsize does not mislabel a negative eta-squared as 'large' (#217)", {
-  # identical, interleaved group profiles -> tiny H -> (degenerate) negative eta-squared
+test_that("kruskal_effsize clamps a degenerate eta-squared to [0,1] and labels it 'small' (#217)", {
+  # identical, interleaved group profiles -> tiny H -> formula yields a negative eta-squared
   d <- data.frame(y = c(1, 2, 3, 1, 2, 3, 1, 2, 3),
                   g = factor(rep(c("a", "b", "c"), each = 3)))
   res <- suppressWarnings(kruskal_effsize(d, y ~ g))
-  expect_true(res$effsize < 0)                        # negative (negligible) effect size
-  expect_equal(as.character(res$magnitude), "small")  # must NOT be reported as 'large'
+  expect_gte(res$effsize, 0)                          # never negative (clamped to [0,1])
+  expect_equal(res$effsize, 0)                        # this degenerate case clamps to 0
+  expect_equal(as.character(res$magnitude), "small")  # and is NOT reported as 'large'
 })
 
 test_that("kruskal_effsize magnitude is unchanged for valid effect sizes (no regression, #217)", {


### PR DESCRIPTION
## Problem (#217)
`kruskal_effsize()` had two related issues for near-null effects:
1. the eta-squared **value was negative** (the reporter notes eta² should lie in `[0, 1]`) — the bias-corrected formula `eta²[H] = (H − k + 1)/(n − k)` can go slightly negative for a tiny `H`;
2. that negative value was then **mislabelled "large"** by the magnitude helper (which used `abs()`).

## Fix
1. **Floor the value to `[0, 1]`** in `eta_squared_h()` (`etasq <- max(0, min(1, etasq))`). `eta²[H]` is a *bias-corrected* estimator (like adjusted R² / ω²), so a small negative for a near-null effect is an artifact; flooring keeps the reported value within the package's **documented** `[0, 1]` range. This is now noted in `?kruskal_effsize`.
2. **Drop `abs()`** in `get_eta_squared_magnitude()` (defensive; values are now ≥ 0 regardless).

(Following the standard convention of reporting a negative bias-corrected variance-explained estimate as 0; e.g. as is commonly done for adjusted R² / ω².)

## No regression
- The floor is a **no-op for every valid value**: mathematically `H ≤ n − 1 ⟹ etasq ≤ 1`; only degenerate negatives are floored to 0. ToothGrowth `len~dose` stays 0.678 / "large".
- Default percentile CI is unaffected in distribution (flooring replicates ≡ flooring the CI bounds, monotone); `ci=TRUE` returns CIs within `[0,1]`.
- `eta_squared_h()` / `get_eta_squared_magnitude()` are used **only** by `kruskal_effsize()`; `eta_squared()`, `cohens_d`, `wilcox_effsize`, `friedman_effsize` are untouched.
- Adversarially reviewed: SAFE.

## Tests
`test-kruskal_effsize.R`: a degenerate case returns effsize `0` (≥ 0) with magnitude "small"; a real strong effect stays "large".

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 158.

Fixes #217
