### PR TITLE
emmeans_test(): fix 'Nonconforming contrast coefficients' with a binary numeric covariate (#206, #86)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- `emmeans_test()` no longer fails with "Nonconforming number of contrast coefficients" when the `covariate` is a numeric variable with only two distinct values (e.g. a 0/1 indicator). The covariate is now correctly averaged over (ANCOVA) instead of being kept as a grid factor ([#206](https://github.com/kassambara/rstatix/issues/206), [#86](https://github.com/kassambara/rstatix/issues/86)).
 - `kruskal_effsize()` now clamps the eta-squared effect size to its valid `[0, 1]` range, so a near-null effect no longer returns a negative value (the formula could yield a small negative for a tiny `H`); consequently it is correctly labelled "small" rather than "large" (the magnitude had used the absolute value) ([#217](https://github.com/kassambara/rstatix/issues/217)).
 - `anova_test()` / `anova_summary()` now return **both** effect sizes when `effect.size = c("pes", "ges")` is requested; previously only partial eta squared was kept ([#180](https://github.com/kassambara/rstatix/issues/180)).
 - `tukey_hsd()` now respects `conf.level` (and other `TukeyHSD()` arguments) for the ungrouped data-frame interface; previously `...` was dropped so the confidence interval was always 95% ([#188](https://github.com/kassambara/rstatix/issues/188)).

--- a/R/emmeans_test.R
+++ b/R/emmeans_test.R
@@ -67,6 +67,13 @@ emmeans_test <- function(data, formula, covariate = NULL, ref.group = NULL,
       paste(collapse = "*")
     data <- dplyr::ungroup(data)
   }
+  # Reference grid for emmeans is built over the comparison variable(s) only
+  # (group + grouping vars). The covariate goes into the model but NOT the grid:
+  # emmeans averages over it (ANCOVA). Keeping the covariate in the grid breaks
+  # for a 2-value numeric covariate, which emmeans keeps as a factor by default
+  # (cov.keep = "2"), producing "Nonconforming number of contrast coefficients"
+  # (#206, #86).
+  emmeans.rhs <- rhs
   if(!is.null(covariate)){
     covariate <- paste(covariate, collapse = "+")
     rhs <- paste(covariate, rhs, sep = "+")
@@ -87,7 +94,7 @@ emmeans_test <- function(data, formula, covariate = NULL, ref.group = NULL,
     comparisons <- get_comparisons(data, variable = !!group, ref.group = !!ref.group)
   }
   method <- get_emmeans_contrasts(data, group, comparisons)
-  formula.emmeans <- stats::as.formula(paste0("~", rhs))
+  formula.emmeans <- stats::as.formula(paste0("~", emmeans.rhs))
   res.emmeans <- emmeans::emmeans(model, formula.emmeans)
   comparisons <- pairwise_emmeans_test(
     res.emmeans, grouping.vars, method = method,

--- a/tests/testthat/test-emmeans_test.R
+++ b/tests/testthat/test-emmeans_test.R
@@ -56,3 +56,30 @@ test_that("emmeans_test works", {
   expect_equal(comparisons, expected_comparisons, tolerance = 1e-4)
   expect_equal(res_emmeans, expected_emmeans, tolerance = 1e-4)
 })
+
+test_that("emmeans_test works with a binary (0/1) numeric covariate (#206, #86)", {
+  skip_if_not_installed("emmeans")
+  df <- mtcars
+  df$am <- factor(df$am)
+  # df$vs is numeric with only 2 distinct values (0/1); this previously errored
+  # with 'Nonconforming number of contrast coefficients'
+  res <- emmeans_test(df, wt ~ am, covariate = vs)
+  expect_s3_class(res, "rstatix_test")
+  expect_equal(nrow(res), 1L)            # am has 2 levels -> a single comparison
+  expect_true(all(c("group1", "group2", "p", "p.adj") %in% colnames(res)))
+  # multiple covariates (incl. a binary one) also work
+  res2 <- emmeans_test(df, wt ~ am, covariate = c(gear, vs))
+  expect_equal(nrow(res2), 1L)
+})
+
+test_that("emmeans_test averages the covariate (correct ANCOVA), not gridding it (#206)", {
+  skip_if_not_installed("emmeans")
+  df <- mtcars
+  df$am <- factor(df$am)
+  res <- emmeans_test(df, wt ~ am, covariate = gear)
+  # equals the ANCOVA emmeans over the group with the covariate held at its mean
+  m   <- stats::lm(wt ~ gear + am, data = df)
+  ref <- as.data.frame(emmeans::contrast(emmeans::emmeans(m, ~ am),
+                                         method = "pairwise", adjust = "none"))
+  expect_equal(abs(res$statistic), abs(ref$t.ratio), tolerance = 1e-6)
+})


### PR DESCRIPTION
## Problem (#206, #86)
`emmeans_test()` failed with **"Nonconforming number of contrast coefficients"** when the ANCOVA `covariate` was a numeric variable with only **two distinct values** (e.g. sex coded 0/1; `mtcars$vs`). Multi-value / continuous covariates worked. Confirmed by @fubin1999's reprex on #206:
```r
mtcars |> emmeans_test(wt ~ am, covariate = vs)   # vs is numeric 0/1 -> ERROR
mtcars |> emmeans_test(wt ~ am, covariate = gear)  # OK
```

## Root cause
The emmeans **reference grid** was built from the full model RHS, which *includes the covariate* (`formula.emmeans <- ~ covariate + group`). emmeans averages over multi-value/continuous covariates, but by its `cov.keep = "2"` default it **keeps a 2-value covariate as a grid factor** → the grid becomes covariate×group and the custom pairwise contrast coefficients (sized for the group's levels) nonconform.

## Fix
Build the emmeans grid over the **comparison variable(s) only** (group + grouping vars); the covariate stays in the `lm()` model and is **averaged over** (correct ANCOVA):
```r
emmeans.rhs <- rhs                 # group (+ grouping vars), before the covariate is prepended
...                                # model still uses the full rhs: lm(outcome ~ covariate + group)
formula.emmeans <- as.formula(paste0("~", emmeans.rhs))
```

## No regression
- **No covariate:** `emmeans.rhs == rhs` → path completely unchanged (the existing grouped `len ~ dose` test passes exactly).
- **Continuous / ≥3-value covariate:** all numeric outputs (estimate/se/df/CI/statistic/p/p.adj) are **byte-identical** before vs after (emmeans averaged the covariate already).
- **Binary covariate:** previously crashed → now returns the correct ANCOVA pairwise comparison.
- `ref.group`, `comparisons`, grouped data, and multiple covariates (`c(cov1, cov2)`) all work.
- Minor improvement: the per-comparison `term` now consistently reports the comparison variable (e.g. `am`) rather than the full model term (`disp*am`).

## Tests
`test-emmeans_test.R` (guarded by `skip_if_not_installed("emmeans")`): a binary covariate now works (incl. `c(gear, vs)`); a multi-value covariate's statistic matches the manual ANCOVA emmeans (covariate held at its mean).

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 163.

Fixes #206
Fixes #86
