### PR TITLE
cohens_d(): honour mu for two-sample tests (independent and paired) (#200)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- `cohens_d()` now honours the `mu` argument for two-sample tests (independent and paired): `mu` is the hypothesized mean difference and is subtracted before standardizing, consistent with the one-sample case. Previously `mu` was silently ignored for two-sample tests. Calls using the default `mu = 0` are unchanged ([#200](https://github.com/kassambara/rstatix/issues/200)).
 - `emmeans_test()` no longer fails with "Nonconforming number of contrast coefficients" when the `covariate` is a numeric variable with only two distinct values (e.g. a 0/1 indicator). The covariate is now correctly averaged over (ANCOVA) instead of being kept as a grid factor ([#206](https://github.com/kassambara/rstatix/issues/206), [#86](https://github.com/kassambara/rstatix/issues/86)).
 - `kruskal_effsize()` now clamps the eta-squared effect size to its valid `[0, 1]` range, so a near-null effect no longer returns a negative value (the formula could yield a small negative for a tiny `H`); consequently it is correctly labelled "small" rather than "large" (the magnitude had used the absolute value) ([#217](https://github.com/kassambara/rstatix/issues/217)).
 - `anova_test()` / `anova_summary()` now return **both** effect sizes when `effect.size = c("pes", "ges")` is requested; previously only partial eta squared was kept ([#180](https://github.com/kassambara/rstatix/issues/180)).

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -29,7 +29,10 @@ NULL
 #'  one or multiple levels giving the corresponding groups. For example,
 #'  \code{formula = TP53 ~ cancer_group}.
 #'@param paired a logical indicating whether you want a paired test.
-#'@param mu theoretical mean, use for one-sample t-test. Default is 0.
+#'@param mu the theoretical mean (one-sample test) or the hypothesized difference
+#'  in means (two-sample test). It is subtracted from the mean difference before
+#'  standardizing, so a non-zero \code{mu} shifts the effect size accordingly.
+#'  Default is 0.
 #'@param var.equal a logical variable indicating whether to treat the two
 #'  variances as being equal. If TRUE then the pooled variance is used to
 #'  estimate the variance otherwise the Welch (or Satterthwaite) approximation
@@ -120,7 +123,8 @@ cohens.d <- function(x, y = NULL, mu = 0, paired = FALSE, var.equal = FALSE,
       OK <- complete.cases(x, y)
       x <- x[OK] - y[OK]
       y <- NULL
-      mu <- 0
+      # keep the user-supplied `mu`: a paired test reduces to a one-sample test
+      # on the differences, where `mu` is the hypothesized mean difference (#200)
       METHOD <- "Paired T-test"
     }
     else {
@@ -201,10 +205,10 @@ get_cohens_d <- function(data, formula, subset = NULL, paired = FALSE, mu = 0, v
     x <- data[[1]] %>% pull(outcome)
     y <- data[[2]] %>% pull(outcome)
     if(paired){
-      d <- paired_sample_d(x, y)
+      d <- paired_sample_d(x, y, mu)
     }
     else{
-      d <- two_independent_sample_d(x, y, var.equal)
+      d <- two_independent_sample_d(x, y, var.equal, mu)
     }
   }
   else{
@@ -238,7 +242,7 @@ get_cohens_d <- function(data, formula, subset = NULL, paired = FALSE, mu = 0, v
 one_sample_d <- function(x, mu = 0){
   (mean(x) - mu)/sd(x)
 }
-two_independent_sample_d <- function(x, y, var.equal = TRUE){
+two_independent_sample_d <- function(x, y, var.equal = TRUE, mu = 0){
   if(var.equal){
     squared.dev <- (c(x - mean(x), y - mean(y)))^2
     n <- length(squared.dev)
@@ -248,10 +252,10 @@ two_independent_sample_d <- function(x, y, var.equal = TRUE){
     SD <- sqrt((var(x) + var(y))/2)
   }
   mean.diff <- mean(x) - mean(y)
-  mean.diff/SD
+  (mean.diff - mu)/SD
 }
-paired_sample_d <- function(x, y){
-  mean(x-y)/sd(x-y)
+paired_sample_d <- function(x, y, mu = 0){
+  (mean(x-y) - mu)/sd(x-y)
 }
 
 

--- a/man/cohens_d.Rd
+++ b/man/cohens_d.Rd
@@ -41,7 +41,10 @@ interest to be compared. For example to compare groups "A" vs "B" and "B" vs
 
 \item{paired}{a logical indicating whether you want a paired test.}
 
-\item{mu}{theoretical mean, use for one-sample t-test. Default is 0.}
+\item{mu}{the theoretical mean (one-sample test) or the hypothesized difference
+in means (two-sample test). It is subtracted from the mean difference before
+standardizing, so a non-zero \code{mu} shifts the effect size accordingly.
+Default is 0.}
 
 \item{var.equal}{a logical variable indicating whether to treat the two
 variances as being equal. If TRUE then the pooled variance is used to

--- a/tests/testthat/test-cohens_d.R
+++ b/tests/testthat/test-cohens_d.R
@@ -1,0 +1,32 @@
+context("test-cohens_d")
+
+oj <- ToothGrowth$len[ToothGrowth$supp == "OJ"]
+vc <- ToothGrowth$len[ToothGrowth$supp == "VC"]
+
+test_that("cohens_d applies mu for an independent two-sample test (#200)", {
+  d0 <- ToothGrowth %>% cohens_d(len ~ supp)
+  d3 <- ToothGrowth %>% cohens_d(len ~ supp, mu = 3)
+  expect_false(isTRUE(all.equal(d0$effsize, d3$effsize)))            # mu now changes the result
+  expected <- ((mean(oj) - mean(vc)) - 3) / sqrt((var(oj) + var(vc)) / 2)
+  expect_equal(as.numeric(d3$effsize), expected, tolerance = 1e-4)
+})
+
+test_that("cohens_d applies mu for a paired two-sample test (#200)", {
+  d0 <- ToothGrowth %>% cohens_d(len ~ supp, paired = TRUE)
+  d3 <- ToothGrowth %>% cohens_d(len ~ supp, paired = TRUE, mu = 3)
+  expect_false(isTRUE(all.equal(d0$effsize, d3$effsize)))
+  diffs <- oj - vc
+  expect_equal(as.numeric(d3$effsize), (mean(diffs) - 3) / sd(diffs), tolerance = 1e-4)
+})
+
+test_that("cohens_d default (mu = 0) is the standard Cohen's d (no regression, #200)", {
+  d_ind <- ToothGrowth %>% cohens_d(len ~ supp)
+  expect_equal(as.numeric(d_ind$effsize),
+               (mean(oj) - mean(vc)) / sqrt((var(oj) + var(vc)) / 2), tolerance = 1e-4)
+  diffs <- oj - vc
+  d_pr <- ToothGrowth %>% cohens_d(len ~ supp, paired = TRUE)
+  expect_equal(as.numeric(d_pr$effsize), mean(diffs) / sd(diffs), tolerance = 1e-4)
+  # one-sample behaviour is unchanged (mu already worked there)
+  os <- ToothGrowth %>% cohens_d(len ~ 1, mu = 20)
+  expect_equal(as.numeric(os$effsize), (mean(ToothGrowth$len) - 20) / sd(ToothGrowth$len), tolerance = 1e-4)
+})


### PR DESCRIPTION
## Problem
`cohens_d()` silently ignored the `mu` argument for **two-sample** tests — it was applied only for the one-sample case (#200). `mu` is the hypothesized mean difference and should shift the effect size.

## Fix
Subtract `mu` before standardizing in both two-sample helpers, and stop discarding the user's `mu` for paired tests:
- `two_independent_sample_d()`: `(mean.diff - mu) / SD`
- `paired_sample_d()`: `(mean(x - y) - mu) / sd(x - y)`
- `cohens.d()` paired branch no longer resets `mu <- 0` (a paired test reduces to a one-sample test on the differences, where `mu` is the hypothesized mean difference).
- `mu` docs updated to describe the two-sample meaning.

This matches `one_sample_d()` and `stats::t.test()` semantics.

## No regression
- Default `mu = 0` is **byte-identical** to before for independent, paired, and one-sample tests (and across `var.equal`, `hedges.correction`, `ci`, `ref.group`/`comparisons`, and grouped data).
- Only a non-zero `mu` (previously silently ignored for two-sample) now changes the result.

## Tests
`test-cohens_d.R`: `mu` shifts the effect size for independent and paired tests to the expected `(mean.diff - mu)/SD`; default `mu = 0` equals the standard Cohen's d; one-sample unchanged.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 170.

Fixes #200
