### PR TITLE
anova_test: fix class order so results work with dplyr (#106, #111)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- `anova_test()` results (grouped and ungrouped) and `get_anova_table()` output are now compatible with `dplyr` verbs again (e.g. `filter()`, `mutate()`, `add_xy_position()`): the class order is corrected so `rstatix_test` precedes `data.frame`, which recent `vctrs`/`dplyr` require ([#106](https://github.com/kassambara/rstatix/issues/106), [#111](https://github.com/kassambara/rstatix/issues/111)).
 - `cohens_d()` now honours the `mu` argument for two-sample tests (independent and paired): `mu` is the hypothesized mean difference and is subtracted before standardizing, consistent with the one-sample case. Previously `mu` was silently ignored for two-sample tests. Calls using the default `mu = 0` are unchanged ([#200](https://github.com/kassambara/rstatix/issues/200)).
 - `emmeans_test()` no longer fails with "Nonconforming number of contrast coefficients" when the `covariate` is a numeric variable with only two distinct values (e.g. a 0/1 indicator). The covariate is now correctly averaged over (ANCOVA) instead of being kept as a grid factor ([#206](https://github.com/kassambara/rstatix/issues/206), [#86](https://github.com/kassambara/rstatix/issues/86)).
 - `kruskal_effsize()` now clamps the eta-squared effect size to its valid `[0, 1]` range, so a near-null effect no longer returns a negative value (the formula could yield a small negative for a tiny `H`); consequently it is correctly labelled "small" rather than "large" (the magnitude had used the absolute value) ([#217](https://github.com/kassambara/rstatix/issues/217)).

--- a/R/anova_test.R
+++ b/R/anova_test.R
@@ -181,7 +181,8 @@ anova_test <- function(data, formula, dv, wid, between, within, covariate, type 
     results
   }
   .append_anova_class <- function(x){
-    class(x) <- c("anova_test", class(x), "rstatix_test")
+    # rstatix_test must come before data.frame for dplyr/vctrs compatibility (#106)
+    class(x) <- c("anova_test", "rstatix_test", class(x))
     x
   }
 
@@ -197,7 +198,8 @@ anova_test <- function(data, formula, dv, wid, between, within, covariate, type 
         mutate(anova = map(.data$anova, .append_anova_class))
     }
     results <- results %>% set_attrs(args = list(data = data))
-    class(results) <- c("grouped_anova_test", class(results), "rstatix_test")
+    # rstatix_test must come before data.frame for dplyr/vctrs compatibility (#106)
+    class(results) <- c("grouped_anova_test", "rstatix_test", class(results))
   }
   else{
     results <- .anova_test(
@@ -240,7 +242,7 @@ get_anova_table_from_simple_test <- function(x, correction = "auto"){
   if(correction.method == "none"){
     res.aov <- x$ANOVA
     attr(res.aov, "args") <- attr(x, "args")
-    class(res.aov) <- c("anova_test", class(res.aov), "rstatix_test")
+    class(res.aov) <- c("anova_test", "rstatix_test", class(res.aov))
     return(res.aov)
   }
   # repeated/mixed design
@@ -273,7 +275,7 @@ get_anova_table_from_simple_test <- function(x, correction = "auto"){
     rownames(res.aov) <- 1:nrow(res.aov)
   }
   res.aov <- res.aov %>% set_attrs(args = .args)
-  class(res.aov) <- c("anova_test", class(res.aov), "rstatix_test")
+  class(res.aov) <- c("anova_test", "rstatix_test", class(res.aov))
   res.aov
 }
 

--- a/tests/testthat/test-anova_test.R
+++ b/tests/testthat/test-anova_test.R
@@ -110,6 +110,34 @@ test_that("anova_test gives a well-formed error for a single-level factor (#137)
   expect_match(msg, "Variable grp has only one level")
 })
 
+test_that("anova_test results are dplyr-compatible: rstatix_test before data.frame (#106)", {
+  g <- ToothGrowth %>% group_by(supp) %>% anova_test(len ~ dose)
+  # class order: the subclasses must come before data.frame (vctrs/dplyr requirement)
+  expect_lt(match("rstatix_test", class(g)), match("data.frame", class(g)))
+  # grouped: filter / mutate must work (previously errored "must be a vector")
+  expect_true(is.data.frame(g %>% dplyr::filter(p < 1)))
+  expect_true(is.data.frame(g %>% dplyr::mutate(z = p)))
+  # ungrouped and get_anova_table() output too
+  u <- ToothGrowth %>% anova_test(len ~ dose)
+  expect_true(is.data.frame(u %>% dplyr::filter(p < 1)))
+  expect_true(is.data.frame(get_anova_table(g) %>% dplyr::filter(p < 1)))
+  # repeated-measures get_anova_table() (with sphericity correction) is dplyr-compatible too
+  set.seed(1)
+  rm <- data.frame(id = factor(rep(1:10, 3)), time = factor(rep(c("t1","t2","t3"), each = 10)),
+                   score = c(rnorm(10, 5), rnorm(10, 6), rnorm(10, 8)))
+  rm.aov <- anova_test(rm, dv = score, wid = id, within = time)
+  expect_true(is.data.frame(get_anova_table(rm.aov, correction = "GG") %>% dplyr::filter(p < 1)))
+  # dispatch is preserved by the reorder
+  expect_true(inherits(u, "anova_test"))
+  expect_true(inherits(g, "grouped_anova_test"))
+})
+
+test_that("add_xy_position on an anova_test gives an informative error, not a class error (#111)", {
+  g <- ToothGrowth %>% group_by(supp) %>% anova_test(len ~ dose)
+  # omnibus ANOVA has no pairwise comparisons: needs a pairwise post-hoc instead
+  expect_error(add_xy_position(g), "group1 and group2")
+})
+
 test_that("anova_test effect.size = c('pes','ges') returns BOTH columns (#180)", {
   both <- iris %>%
     anova_test(Sepal.Length ~ Sepal.Width + Species, effect.size = c("pes", "ges")) %>%


### PR DESCRIPTION
## Problem (#106, #111)
`anova_test()` results — grouped and ungrouped — and `get_anova_table()` output put `rstatix_test` **after** `data.frame` in the class vector (e.g. grouped: `grouped_anova_test, tbl_df, tbl, data.frame, rstatix_test`). Recent `vctrs`/`dplyr` reject this ("the subclass must come before `<data.frame>`"), so `filter()` / `mutate()` / `add_xy_position()` on an anova_test result errored with *"must be a vector, not a `<…>` object."*

## Fix
Reorder all four class assignments in `R/anova_test.R` so the subclasses (including `rstatix_test`) come **before** `data.frame`:
`c(prefix, class(x), "rstatix_test")` → `c(prefix, "rstatix_test", class(x))`
(`.append_anova_class()`, the grouped result, and both `get_anova_table_from_simple_test()` branches). Same classes — only the order changes — matching the rest of the package's convention.

## No regression
- Class membership is unchanged, so all dispatch still works: `print.anova_test`, `plot.anova_test`, `get_anova_table()`/`is_grouped_anova_test()` (which keys off the `anova` column, not class order), and `get_test_label()`.
- ANOVA **values are unchanged** (the existing exact-value assertions, incl. GG/HF corrections, stay green).
- `filter()`/`mutate()` now work on ungrouped, grouped, and `get_anova_table()` outputs (incl. repeated-measures with sphericity corrections).

## Note on #111 (`add_xy_position` on an anova_test)
The class error is gone, but `add_xy_position()` on an omnibus ANOVA table still (correctly) reports *"data should contain group1 and group2 columns"* — an ANOVA has no pairwise comparisons. To position p-values on a plot, use a pairwise post-hoc that returns `group1`/`group2` (e.g. `tukey_hsd()`, `emmeans_test()`, or `pairwise_t_test()`).

## Tests
`test-anova_test.R`: class order (`rstatix_test` before `data.frame`); `filter()`/`mutate()` succeed on grouped, ungrouped, and `get_anova_table()` (incl. RM/GG); dispatch preserved; `add_xy_position()` gives the informative pairwise-columns message.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 179.

Fixes #106
Refs #111
