### PR TITLE
get_summary_stats(): add a digits argument for rounding precision (#145, #186, #218)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+- `get_summary_stats()` gains a `digits` argument to control the number of decimal places (default 3); useful when summarizing very small values that would otherwise round to 0 ([#145](https://github.com/kassambara/rstatix/issues/145), [#186](https://github.com/kassambara/rstatix/issues/186), [#218](https://github.com/kassambara/rstatix/issues/218)).
+
 ## Main changes
 
 ## Minor changes

--- a/R/get_summary_stats.R
+++ b/R/get_summary_stats.R
@@ -14,6 +14,9 @@ NULL
 #'  show. Example: \code{show = c("n", "mean", "sd")}. This is used to filter
 #'  the output after computation.
 #' @param probs numeric vector of probabilities with values in [0,1]. Used only when type = "quantile".
+#'@param digits integer indicating the number of decimal places to round the
+#'  summary statistics to. Default is 3. Increase it when summarizing very small
+#'  values that would otherwise round to 0.
 #'@return A data frame containing descriptive statistics, such as: \itemize{
 #'  \item \strong{n}: the number of individuals \item \strong{min}: minimum
 #'  \item \strong{max}: maximum \item \strong{median}: median \item
@@ -50,12 +53,12 @@ get_summary_stats <- function(
   data, ..., type = c("full", "common", "robust",  "five_number",
                       "mean_sd", "mean_se", "mean_ci", "median_iqr", "median_mad", "quantile",
                       "mean", "median",  "min", "max" ),
-  show = NULL, probs = seq(0, 1, 0.25)
+  show = NULL, probs = seq(0, 1, 0.25), digits = 3
   ){
   type = match.arg(type)
   if(is_grouped_df(data)){
     results <- data %>%
-      doo(get_summary_stats, ..., type = type, show = show, probs = probs)
+      doo(get_summary_stats, ..., type = type, show = show, probs = probs, digits = digits)
     return(results)
   }
   data <- data %>% select_numeric_columns()
@@ -88,7 +91,7 @@ get_summary_stats <- function(
     full_summary(data)
   ) %>%
     dplyr::ungroup() %>%
-    dplyr::mutate_if(is.numeric, round, digits = 3)
+    dplyr::mutate_if(is.numeric, round, digits = digits)
 
   if(!is.null(show)){
     show <- unique(c("variable", "n", show))

--- a/man/get_summary_stats.Rd
+++ b/man/get_summary_stats.Rd
@@ -10,7 +10,8 @@ get_summary_stats(
   type = c("full", "common", "robust", "five_number", "mean_sd", "mean_se", "mean_ci",
     "median_iqr", "median_mad", "quantile", "mean", "median", "min", "max"),
   show = NULL,
-  probs = seq(0, 1, 0.25)
+  probs = seq(0, 1, 0.25),
+  digits = 3
 )
 }
 \arguments{
@@ -30,6 +31,10 @@ show. Example: \code{show = c("n", "mean", "sd")}. This is used to filter
 the output after computation.}
 
 \item{probs}{numeric vector of probabilities with values in [0,1]. Used only when type = "quantile".}
+
+\item{digits}{integer indicating the number of decimal places to round the
+summary statistics to. Default is 3. Increase it when summarizing very small
+values that would otherwise round to 0.}
 }
 \value{
 A data frame containing descriptive statistics, such as: \itemize{

--- a/tests/testthat/test-get_summary_stats.R
+++ b/tests/testthat/test-get_summary_stats.R
@@ -11,3 +11,27 @@ test_that("Checking that get_summary_stats keeps the order of columns specified 
   expected_var_order <- c("a", "c", "b")
   expect_equal(obtained_var_order, expected_var_order)
 })
+
+test_that("get_summary_stats `digits` controls the rounding precision (#145, #186, #218)", {
+  small <- data.frame(x = c(0.0001234, 0.0002, 0.00033, 0.00041))
+  # default (digits = 3) rounds very small values to 0
+  expect_equal(get_summary_stats(small, x, type = "mean")$mean, 0)
+  # a higher `digits` keeps the precision
+  expect_gt(get_summary_stats(small, x, type = "mean", digits = 8)$mean, 0)
+})
+
+test_that("get_summary_stats default (digits = 3) output is unchanged (no regression, #145)", {
+  for (ty in c("full", "common", "mean_sd", "quantile", "robust")) {
+    expect_equal(
+      ToothGrowth %>% get_summary_stats(len, type = ty),
+      ToothGrowth %>% get_summary_stats(len, type = ty, digits = 3)
+    )
+  }
+  # grouped: default unchanged, and `digits` is honoured per group
+  expect_equal(
+    ToothGrowth %>% group_by(supp) %>% get_summary_stats(len),
+    ToothGrowth %>% group_by(supp) %>% get_summary_stats(len, digits = 3)
+  )
+  g8 <- ToothGrowth %>% group_by(supp) %>% get_summary_stats(len, type = "mean", digits = 8)
+  expect_equal(nrow(g8), 2L)
+})


### PR DESCRIPTION
## Problem
`get_summary_stats()` hard-coded `round(..., digits = 3)`, so very small values were shown as `0` and the precision couldn't be changed (#145, #186, #218).

## Fix
Add a `digits` argument (default `3`) to `get_summary_stats()`, thread it through the grouped path, and use it in the rounding step:
```r
ToothGrowth %>% get_summary_stats(len, type = "mean")             # digits = 3 (default)
small %>% get_summary_stats(x, type = "mean", digits = 8)         # keep small-value precision
```

## No regression
- Default `digits = 3` is **byte-identical** to before — verified for all 14 `type=` variants, ungrouped and grouped.
- The integer `n` column is unaffected.
- `show=`, `probs=` (quantile) and multi-variable selection all still work and honour `digits`.

## Tests
`test-get_summary_stats.R`: `digits = 8` keeps a tiny value non-zero (was 0 at default); default equals explicit `digits = 3` across `type=` variants and grouped data.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 188.

Fixes #145
Fixes #186
Fixes #218
