### PR TITLE
get_test_label(): include sample size n for ANOVA (#150)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 ## Bug fixes
 
+- `get_test_label()` now includes the sample size `n` for ANOVA results (e.g. `Anova, F(1,58) = 105.06, p = <0.0001, eta2[g] = 0.644, n = 60`), consistent with the other tests; it was previously dropped because the slicing step stripped the attributes `get_n()` needs ([#150](https://github.com/kassambara/rstatix/issues/150)).
 - The comparison tests (`t_test()`, `wilcox_test()`, `dunn_test()`, `emmeans_test()`, etc.) now drop unused levels of the grouping factor, so a filtered factor that still carries empty levels no longer triggers "not enough observations" errors — matching `stats::t.test()` ([#133](https://github.com/kassambara/rstatix/issues/133)).
 - `wilcox_test()` and `pairwise_wilcox_test()` no longer error on degenerate (all-tied / constant) data. The location confidence interval (which can fail to compute on such data) is now requested only when `detailed = TRUE`, so the default call returns gracefully; `statistic`/`p` are unchanged ([#79](https://github.com/kassambara/rstatix/issues/79), [#167](https://github.com/kassambara/rstatix/issues/167)).
 - `anova_test()` results (grouped and ungrouped) and `get_anova_table()` output are now compatible with `dplyr` verbs again (e.g. `filter()`, `mutate()`, `add_xy_position()`): the class order is corrected so `rstatix_test` precedes `data.frame`, which recent `vctrs`/`dplyr` require ([#106](https://github.com/kassambara/rstatix/issues/106), [#111](https://github.com/kassambara/rstatix/issues/111)).

--- a/R/get_test_label.R
+++ b/R/get_test_label.R
@@ -149,8 +149,13 @@ get_test_label <- function(stat.test, description = NULL, p.col = "p",
   )
   stop_ifnot_class(stat.test, .class = names(allowed.tests))
   is_anova_test <- inherits(stat.test, "anova_test")
+  anova.n <- NA
   if(is_anova_test){
     stat.test <- get_anova_table(stat.test, correction = correction)
+    # derive the sample size now, before the slice below strips the anova_test
+    # class/attributes that get_n() needs to compute n for ANOVA (#150). The total
+    # sample size is the same for every effect row, so a single value is taken.
+    anova.n <- get_n(stat.test)[1]
     if(is.null(row)) row <-  nrow(stat.test) # consider the last row
   }
   if(!is.null(row)) {
@@ -163,6 +168,7 @@ get_test_label <- function(stat.test, description = NULL, p.col = "p",
   statistic <- get_statistic(stat.test)
   df <- get_df(stat.test)
   n <- get_n(stat.test)
+  if(is_anova_test) n <- anova.n   # use the n derived before the class was stripped (#150)
   effect <- get_effect_size(stat.test, type)
   effect.size <- effect$value
   effect.size.text <- effect$text

--- a/tests/testthat/test-get_test_label.R
+++ b/tests/testthat/test-get_test_label.R
@@ -1,0 +1,28 @@
+context("test-get_test_label")
+
+test_that("get_test_label includes the sample size n for ANOVA (#150)", {
+  one_way <- get_test_label(ToothGrowth %>% anova_test(len ~ dose),
+                            detailed = TRUE, type = "text")
+  expect_match(one_way, "n = 60")
+  # two-way: total sample size
+  two_way <- get_test_label(ToothGrowth %>% anova_test(len ~ supp * dose),
+                            detailed = TRUE, type = "text")
+  expect_match(two_way, "n = 60")
+  # repeated measures: n = number of subjects (wid)
+  set.seed(1)
+  rm <- data.frame(id = factor(rep(1:10, 3)),
+                   time = factor(rep(c("t1", "t2", "t3"), each = 10)),
+                   score = rnorm(30))
+  rm_label <- get_test_label(anova_test(rm, dv = score, wid = id, within = time),
+                             detailed = TRUE, type = "text")
+  expect_match(rm_label, "n = 10")
+  # expression type still builds without error
+  expect_silent(get_test_label(ToothGrowth %>% anova_test(len ~ dose), detailed = TRUE))
+})
+
+test_that("get_test_label is unchanged for non-ANOVA tests and non-detailed labels (#150)", {
+  expect_match(get_test_label(ToothGrowth %>% t_test(len ~ supp), detailed = TRUE, type = "text"), "n = 60")
+  expect_match(get_test_label(ToothGrowth %>% kruskal_test(len ~ dose), detailed = TRUE, type = "text"), "n = 60")
+  # the non-detailed ANOVA label has no n (only the description + p)
+  expect_false(grepl("n =", get_test_label(ToothGrowth %>% anova_test(len ~ dose), type = "text")))
+})


### PR DESCRIPTION
## Problem
`get_test_label(..., detailed = TRUE)` showed the sample size `n` for t-test / Kruskal-Wallis etc. but **not for ANOVA** (#150):
```
Anova, F(1,58) = 105.06, p = <0.0001, eta2[g] = 0.644            # n missing
T test, t(55.31) = 1.92, p = 0.061, n = 60
```

## Root cause
`get_n()` derives `n` for ANOVA from the `anova_test` class + stored `args`, but `get_test_label()` sliced the table (`keep_only_tbl_df_classes() %>% slice(row)`) **before** calling `get_n()`, stripping the class — so `get_n()` returned `NA` and the label dropped `n`.

## Fix
Capture `n` for ANOVA **before** the slice (while the class/attrs are intact) and use it:
```r
if (is_anova_test) anova.n <- get_n(stat.test)[1]   # total sample size (uniform across effects)
...
if (is_anova_test) n <- anova.n
```
Now ANOVA labels include `n` (one-way, two-way, and repeated-measures where `n` = number of subjects).

## No regression
- Non-ANOVA labels (t-test, Wilcoxon, Kruskal-Wallis, pairwise, chisq, Welch ANOVA) are **unchanged** — the new branch is guarded by `is_anova_test` and is a no-op otherwise.
- The non-detailed ANOVA label still has no `n`. `row=` and `correction=` (GG/HF) still work; only the displayed label changes.

## Tests
`test-get_test_label.R`: ANOVA labels include `n` (one-way/two-way/RM, text + expression build); non-ANOVA labels and non-detailed labels unchanged.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 205.

Fixes #150
