### PR TITLE
Report the test variant (Welch/paired/Mann-Whitney/signed-rank) in the detailed method column (#124)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## Main changes
 
+- The `method` column of detailed test results (`detailed = TRUE`) now reports the specific test variant instead of a generic label: `t_test()` gives "Welch t-test" / "T-test" / "Paired t-test" / "One-sample t-test", and `wilcox_test()` gives "Wilcoxon rank sum test" / "Wilcoxon signed rank test" ([#124](https://github.com/kassambara/rstatix/issues/124)). Non-detailed output and the p-values/statistics are unchanged.
+
 ## Minor changes
 
 - Updated the CRAN checks badge in the README to the current `badges.cranchecks.info` endpoint (the old `cranchecks.info` badge no longer resolves) ([#174](https://github.com/kassambara/rstatix/issues/174)).

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -345,6 +345,20 @@ get_stat_method <- function(x){
   if(inherits(x, c("aov", "anova"))){
     return("Anova")
   }
+  # Report the specific t-test / Wilcoxon variant rather than a generic label (#124)
+  test.method <- x$method
+  if(!is.null(test.method)){
+    if(grepl("t-test", test.method, ignore.case = TRUE)){
+      if(grepl("welch", test.method, ignore.case = TRUE)) return("Welch t-test")
+      if(grepl("paired", test.method, ignore.case = TRUE)) return("Paired t-test")
+      if(grepl("one sample", test.method, ignore.case = TRUE)) return("One-sample t-test")
+      return("T-test")  # Student's two-sample t-test (var.equal = TRUE)
+    }
+    if(grepl("wilcoxon", test.method, ignore.case = TRUE)){
+      if(grepl("signed rank", test.method, ignore.case = TRUE)) return("Wilcoxon signed rank test")
+      return("Wilcoxon rank sum test")  # a.k.a. Mann-Whitney (unpaired)
+    }
+  }
   available.methods <- c(
     "T-test", "Wilcoxon", "Kruskal-Wallis",
     "Pearson", "Spearman", "Kendall", "Sign-Test",

--- a/tests/testthat/test-t_test.R
+++ b/tests/testthat/test-t_test.R
@@ -18,6 +18,13 @@ test_that("pairwise_t_test drops unused factor levels (#133)", {
   expect_equal(nrow(dp %>% pairwise_t_test(y ~ g, paired = TRUE)), 3L)
 })
 
+test_that("t_test detailed method reports the variant (#124)", {
+  expect_equal((ToothGrowth %>% t_test(len ~ supp, detailed = TRUE))$method, "Welch t-test")
+  expect_equal((ToothGrowth %>% t_test(len ~ supp, var.equal = TRUE, detailed = TRUE))$method, "T-test")
+  expect_equal((ToothGrowth %>% t_test(len ~ supp, paired = TRUE, detailed = TRUE))$method, "Paired t-test")
+  expect_equal((ToothGrowth %>% t_test(len ~ 1, mu = 20, detailed = TRUE))$method, "One-sample t-test")
+})
+
 test_that("t_test / wilcox_test handle a filtered factor with an unused level (#133)", {
   # 2 species kept, but the 'virginica' factor level is retained (empty) - used to error
   d <- iris %>% filter(Species %in% c("setosa", "versicolor"))

--- a/tests/testthat/test-wilcox_test.R
+++ b/tests/testthat/test-wilcox_test.R
@@ -128,6 +128,13 @@ test_that("Empty values are not counting in group n size (104)", {
   expect_equal(c(res$n1, res$n2), c(9, 7))
 })
 
+test_that("wilcox_test detailed method reports the variant (#124)", {
+  expect_equal((ToothGrowth %>% wilcox_test(len ~ supp, detailed = TRUE))$method,
+               "Wilcoxon rank sum test")
+  expect_equal((ToothGrowth %>% wilcox_test(len ~ supp, paired = TRUE, detailed = TRUE))$method,
+               "Wilcoxon signed rank test")
+})
+
 test_that("wilcox_test does not crash on degenerate/all-tied data (#79, #167)", {
   set.seed(1)
   deg <- data.frame(value = c(0,0,0,0, 0,0,0,0,0), g = rep(c("a","b"), c(4, 5)))


### PR DESCRIPTION
## Problem
`detailed = TRUE` results reported a generic `method = "T-test"` / `"Wilcoxon"`, hiding whether it was a Welch vs Student, paired, or one-sample t-test, and Mann-Whitney (rank-sum) vs signed-rank Wilcoxon (#124).

## Fix
`get_stat_method()` now derives the variant from the underlying htest:
- t-test → `"Welch t-test"` (default), `"T-test"` (Student, `var.equal = TRUE`), `"Paired t-test"`, `"One-sample t-test"`
- Wilcoxon → `"Wilcoxon rank sum test"` (unpaired / Mann-Whitney), `"Wilcoxon signed rank test"` (paired / one-sample)

```r
ToothGrowth %>% t_test(len ~ supp, detailed = TRUE)                 # method = "Welch t-test"
ToothGrowth %>% t_test(len ~ supp, var.equal = TRUE, detailed = TRUE) # method = "T-test"
ToothGrowth %>% wilcox_test(len ~ supp, paired = TRUE, detailed = TRUE) # "Wilcoxon signed rank test"
```

## No regression
- Only the `method` **string** in `detailed = TRUE` output changes; `statistic`/`p`/`estimate`/`df`/`conf.*` are unchanged.
- Non-detailed output has no `method` column (unchanged).
- Other tests' labels (Pearson/Spearman/Kendall, Kruskal-Wallis, Sign test, Chi-square, ANOVA, Cohen's d) are unchanged.

## ggpubr compatibility
`stat_pvalue_manual()` doesn't read this column; `geom_pwc()` derives its method label from `get_description()` (the test name, not this column) and overwrites it; `compare_means()` is independent. ggpubr's full test suite passes against this change (FAIL 0, PASS 404).

## Tests
`test-t_test.R` / `test-wilcox_test.R`: detailed `method` reflects each variant.

## Verification
`Rscript --vanilla -e 'devtools::test()'` → FAIL 0 | PASS 211.

Fixes #124
