### PR TITLE
Handle scientific notation in p-value formatting (#112, #148)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 ## Bug fixes
 
+- `p_format()` no longer strips a trailing `0` from the exponent of scientific-notation p-values (e.g. `p_format(5.1e-10)` returned `"5.1e-1"`; it now correctly returns `"5.1e-10"`). Ordinary decimal formatting, including `trailing.zero` padding, is unchanged ([#112](https://github.com/kassambara/rstatix/issues/112)).
+- `p_mark_significant()` no longer produces `"e-NA"` (with a coercion warning) when given a scientific-notation p-value string such as the output of `p_format()` on `1e-4`; it now correctly returns e.g. `"1e-04****"` ([#148](https://github.com/kassambara/rstatix/issues/148)).
 - `get_test_label()` now includes the sample size `n` for ANOVA results (e.g. `Anova, F(1,58) = 105.06, p = <0.0001, eta2[g] = 0.644, n = 60`), consistent with the other tests; it was previously dropped because the slicing step stripped the attributes `get_n()` needs ([#150](https://github.com/kassambara/rstatix/issues/150)).
 - The comparison tests (`t_test()`, `wilcox_test()`, `dunn_test()`, `emmeans_test()`, etc.) now drop unused levels of the grouping factor, so a filtered factor that still carries empty levels no longer triggers "not enough observations" errors — matching `stats::t.test()` ([#133](https://github.com/kassambara/rstatix/issues/133)).
 - `wilcox_test()` and `pairwise_wilcox_test()` no longer error on degenerate (all-tied / constant) data. The location confidence interval (which can fail to compute on such data) is now requested only when `detailed = TRUE`, so the default call returns gracefully; `statistic`/`p` are unchanged ([#79](https://github.com/kassambara/rstatix/issues/79), [#167](https://github.com/kassambara/rstatix/issues/167)).

--- a/R/p_value.R
+++ b/R/p_value.R
@@ -250,7 +250,11 @@ remove_leading_zero <- function(x){
     as.character()
 }
 remove_trailing_zero <- function(x){
-  gsub("\\.?0+$", "", x)
+  # Don't strip zeros from scientific notation (e.g. "5.1e-10"): the exponent's
+  # zeros are significant. Only the decimal part is padded/trimmed (#112)
+  is.sci <- grepl("e[-+]?[0-9]", x, ignore.case = TRUE)
+  x[!is.sci] <- gsub("\\.?0+$", "", x[!is.sci])
+  x
 }
 
 # Select p-value columns: p and p.adj -----------------------

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -83,10 +83,24 @@ round_column <- function(data, ...,  digits = 0){
 
 # Extract or replace number from character string
 extract_number <- function(x){
-  as.numeric(gsub("[^0-9.-]+", "", as.character(x)))
+  x <- as.character(x)
+  # Scientific notation (e.g. "1e-04") loses its exponent under the generic
+  # regex below (the "e" is dropped -> "1-04" -> NA); parse those explicitly,
+  # keeping non-scientific strings on the original byte-identical path (#148)
+  is.sci <- grepl("[0-9](e|E)[-+]?[0-9]", x)
+  res <- numeric(length(x))
+  res[!is.sci] <- as.numeric(gsub("[^0-9.-]+", "", x[!is.sci]))
+  res[is.sci]  <- as.numeric(gsub("[^0-9.eE+-]+", "", x[is.sci]))
+  res
 }
 replace_number <- function(x, replacement = ""){
-  gsub("[0-9.]", replacement, as.character(x))
+  x <- as.character(x)
+  # For scientific notation, strip the whole number (incl. exponent) so the
+  # remaining "leading character" is the genuine prefix and not "e-" (#148)
+  is.sci <- grepl("[0-9](e|E)[-+]?[0-9]", x)
+  out <- gsub("[0-9.]", replacement, x)
+  out[is.sci] <- gsub("[-+]?[0-9.]+([eE][-+]?[0-9]+)?", replacement, x[is.sci])
+  out
 }
 
 # Add columns into data frame

--- a/tests/testthat/test-p_format.R
+++ b/tests/testthat/test-p_format.R
@@ -1,0 +1,25 @@
+context("test-p_format")
+
+test_that("p_format preserves scientific-notation exponents (#112)", {
+  # the trailing 0 of "e-10" was wrongly stripped, giving "5.1e-1"
+  expect_equal(p_format(5.1e-10, accuracy = 1e-15), "5.1e-10")
+  expect_equal(p_format(5.1e-11, accuracy = 1e-15), "5.1e-11")
+  expect_equal(p_format(1e-20, accuracy = 1e-30), "1e-20")
+})
+
+test_that("p_format is unchanged for ordinary decimal p-values (#112)", {
+  expect_equal(p_format(c(0.1, 0.01)), c("0.1", "0.01"))
+  # trailing.zero padding (its intended use) still works
+  expect_equal(p_format(c(0.1, 0.01), trailing.zero = TRUE), c("0.10", "0.01"))
+  expect_equal(p_format(c(0.5, 0.001, 0.049)), c("0.5", "0.001", "0.049"))
+  # very small values below the accuracy threshold still collapse to the sentinel
+  expect_equal(p_format(1e-8), "<0.0001")
+})
+
+test_that("extract_number parses scientific notation without dropping the exponent (#148)", {
+  expect_equal(extract_number("1e-04"), 1e-4)
+  expect_equal(extract_number("<0.0001"), 1e-4)
+  # ordinary strings are unchanged
+  expect_equal(extract_number("0.001"), 0.001)
+  expect_equal(extract_number(c("0.05", "1e-04")), c(0.05, 1e-4))
+})

--- a/tests/testthat/test-p_mark_significance.R
+++ b/tests/testthat/test-p_mark_significance.R
@@ -4,3 +4,34 @@ test_that("p_mark_significance works when NA only", {
   na_signif <- p_mark_significant(NA)
   expect_equal(na_signif, "NA")
 })
+
+test_that("p_mark_significant handles scientific-notation strings (#148)", {
+  # The reported edge case: a formatted scientific p-value used to yield "e-NA"
+  # with a coercion warning
+  res <- expect_warning(
+    data.frame(p = 1e-4) %>% p_format() %>% p_mark_significant(),
+    regexp = NA
+  )
+  expect_equal(res$p, "1e-04****")
+  expect_false(grepl("NA", res$p))
+})
+
+test_that("p_mark_significant is robust to mixed-magnitude scientific vectors (#148)", {
+  # a tiny + a large p makes format.pval render the whole vector in scientific
+  # notation; this used to yield "e-NA" for every element
+  res <- expect_warning(
+    data.frame(p = c(1e-4, 0.5)) %>% p_format() %>% p_mark_significant(),
+    regexp = NA
+  )
+  expect_false(any(grepl("NA", res$p)))     # no coercion artefact
+  expect_false(any(grepl("e-$|e$", res$p))) # no dangling exponent
+  expect_true(grepl("\\*\\*\\*\\*$", res$p[1]))  # 1e-4 is highly significant
+  expect_false(grepl("\\*", res$p[2]))            # 0.5 is not significant
+})
+
+test_that("p_mark_significant is unchanged for ordinary decimal strings (#148)", {
+  expect_equal(p_mark_significant("0.001"), "0.001***")
+  expect_equal(p_mark_significant("0.5"), "0.5")
+  df <- data.frame(p = c(0.5, 0.001, 0.049)) %>% p_format() %>% p_mark_significant()
+  expect_equal(df$p, c("0.5", "0.001***", "0.049*"))
+})


### PR DESCRIPTION
## Scientific notation in p-value formatting

Two related bugs where the p-value formatting helpers mishandled scientific notation.

### #112 — `p_format()` stripped a trailing `0` from the exponent
```r
p_format(5.1e-10, accuracy = 1e-15)
#> was: "5.1e-1"   now: "5.1e-10"
p_format(5.1e-11, accuracy = 1e-15)
#> "5.1e-11"  (already correct, unchanged)
```
`remove_trailing_zero()` applied `gsub("\\.?0+$", "", x)` to the whole string, so the `0` in the exponent `e-10` was removed. It now skips scientific-notation strings (their exponent zeros are significant); ordinary decimal formatting — including `trailing.zero` padding — is unchanged.

### #148 — `p_mark_significant()` produced `"e-NA"`
```r
data.frame(p = 1e-4) |> p_format() |> p_mark_significant()
#> was: "e-NA"  (with "NAs introduced by coercion" warning)
#> now: "1e-04****"
```
`extract_number()` deleted the `e` (`"1e-04"` → `"1-04"` → `NA`) and `replace_number()` left `"e-"` as a spurious prefix. Both now parse/strip the exponent correctly.

### No regression
Both fixes gate the new behavior behind a scientific-notation probe, so any non-scientific string takes the exact original code path and is byte-identical. The three changed internal helpers are each called from a single site (`p_format` / `p_mark_significant`). Added regression tests for the fixed cases plus no-regression tests for ordinary decimals; full suite green (`FAIL 0`).
