### PR TITLE
Space significance brackets by exactly step.increase (#201)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 
 ## Bug fixes
 
+- `get_y_position()`/`add_y_position()` now space significance brackets by exactly `step.increase`. Previously the gap between consecutive brackets was `step.increase * n/(n-1)` (wider than requested) for `n >= 2` comparisons. **This changes the computed `y.position` values for plots with 3 or more groups** (brackets are slightly closer together); single-comparison (two-group) plots and `ref.group = "all"` are unchanged ([#201](https://github.com/kassambara/rstatix/issues/201)).
 - `get_test_label()` now includes the sample size `n` for ANOVA results (e.g. `Anova, F(1,58) = 105.06, p = <0.0001, eta2[g] = 0.644, n = 60`), consistent with the other tests; it was previously dropped because the slicing step stripped the attributes `get_n()` needs ([#150](https://github.com/kassambara/rstatix/issues/150)).
 - The comparison tests (`t_test()`, `wilcox_test()`, `dunn_test()`, `emmeans_test()`, etc.) now drop unused levels of the grouping factor, so a filtered factor that still carries empty levels no longer triggers "not enough observations" errors — matching `stats::t.test()` ([#133](https://github.com/kassambara/rstatix/issues/133)).
 - `wilcox_test()` and `pairwise_wilcox_test()` no longer error on degenerate (all-tied / constant) data. The location confidence interval (which can fail to compute on such data) is now requested only when `detailed = TRUE`, so the default call returns gracefully; `statistic`/`p` are unchanged ([#79](https://github.com/kassambara/rstatix/issues/79), [#167](https://github.com/kassambara/rstatix/issues/167)).

--- a/R/get_pvalue_position.R
+++ b/R/get_pvalue_position.R
@@ -136,7 +136,6 @@ get_y_position_core <- function(data, formula, fun = "max", ref.group = NULL, co
   ncomparisons <- length(comparisons)
   group1 <- comparisons %>% get_group(1)
   group2 <- comparisons %>% get_group(2)
-  k <- 1.08
 
   # Estimate y axis scale
   yscale <- get_y_scale(data, y = outcome, group = group, fun = fun, stack = stack)
@@ -144,13 +143,14 @@ get_y_position_core <- function(data, formula, fun = "max", ref.group = NULL, co
   else if(scales %in% c("free", "free_y")){
     step.increase <- step.increase*(yscale$max - yscale$min)
   }
-  # ystart <- k*yscale$max
   ystart <- yscale$max + step.increase
-  yend <- ystart + (step.increase*ncomparisons)
+  # The seq() below spreads ncomparisons brackets over [ystart, yend], so the
+  # gap between consecutive brackets is (yend - ystart)/(ncomparisons - 1).
+  # Using (ncomparisons - 1) here makes that gap exactly step.increase (#201).
+  yend <- ystart + (step.increase*(ncomparisons-1))
 
   if(is.null(ref.group)) ref.group <- ""
   if(ref.group %in% c("all", ".all.")){
-   # y.position <- yscale$y*k
     y.position <- yscale$y + step.increase
   }
   else{

--- a/tests/testthat/test-get_pvalue_position.R
+++ b/tests/testthat/test-get_pvalue_position.R
@@ -1,0 +1,31 @@
+context("test-get_pvalue_position")
+
+test_that("add_y_position spaces brackets by exactly step.increase (#201)", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+  ys <- rstatix:::get_y_scale(df, "len", "dose", "max")
+  step <- 0.12 * (ys$max - ys$min)   # fixed scales: step.increase scaled to data units
+  st <- df %>% t_test(len ~ dose) %>% add_y_position(step.increase = 0.12)
+  expect_equal(nrow(st), 3L)
+  # consecutive brackets are step.increase apart (was step*n/(n-1) before the fix)
+  expect_equal(diff(st$y.position), rep(step, 2), tolerance = 1e-6)
+  # first bracket sits one step above the data max
+  expect_equal(st$y.position[1], ys$max + step, tolerance = 1e-6)
+})
+
+test_that("add_y_position is unchanged for a single comparison (#201 no-regression)", {
+  ys <- rstatix:::get_y_scale(ToothGrowth, "len", "supp", "max")
+  step <- 0.12 * (ys$max - ys$min)
+  st <- ToothGrowth %>% t_test(len ~ supp) %>% add_y_position(step.increase = 0.12)
+  expect_equal(nrow(st), 1L)
+  # seq(length.out = 1) returns `from`, so this value is identical old vs new
+  expect_equal(st$y.position, ys$max + step, tolerance = 1e-6)
+})
+
+test_that("add_y_position ref.group = 'all' positions are unaffected (#201 no-regression)", {
+  st <- ToothGrowth %>%
+    t_test(len ~ dose, ref.group = "all") %>%
+    add_y_position(step.increase = 0.12)
+  expect_equal(nrow(st), 3L)
+  expect_false(any(is.na(st$y.position)))
+})


### PR DESCRIPTION
## Significance brackets are now spaced by exactly `step.increase`

`get_y_position()` / `add_y_position()` lay out `n` brackets with
`y.position <- seq(from = ystart, to = yend, length.out = n)`, where
`yend <- ystart + step.increase * n`. Because `seq()` divides the span into
`n - 1` gaps, the actual spacing was `step.increase * n/(n-1)` — wider than the
requested `step.increase`, especially for few comparisons (2× for n = 2,
1.5× for n = 3, …).

Setting `yend <- ystart + step.increase * (n - 1)` makes the gap exactly
`step.increase`:

```r
df <- ToothGrowth; df$dose <- factor(df$dose)
df %>% t_test(len ~ dose) %>% add_y_position(step.increase = 0.12)
# diff(y.position): was 2.232 between brackets, now 1.488 (= step.increase in data units)
```

### Scope of the change
This changes the computed `y.position` values for plots with **3 or more groups**
(brackets sit slightly closer together). Unchanged:
- single-comparison (two-group) plots — `seq(length.out = 1)` returns `ystart`
  regardless of `yend`, so the value is byte-identical;
- the `ref.group = "all"` layout (separate code path).

Also removes the unused `k <- 1.08` variable. Added regression and
no-regression tests; full suite green (`FAIL 0`).
