### PR TITLE
Fix cor_test tidyselect deprecation and clarify anova_test contrasts docs (#202, #225)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,11 @@
 ## Minor changes
 
 - Updated the CRAN checks badge in the README to the current `badges.cranchecks.info` endpoint (the old `cranchecks.info` badge no longer resolves) ([#174](https://github.com/kassambara/rstatix/issues/174)).
+- Clarified the `?anova_test` documentation about contrasts: the formula / `dv` + `between`/`within` interface fits the model internally with `contr.sum` (matching SPSS / type-III), whereas a pre-fitted `lm()`/`aov()` keeps its own contrasts (R's default `contr.treatment` unless set otherwise) ([#225](https://github.com/kassambara/rstatix/issues/225)).
 
 ## Bug fixes
 
+- `cor_test()` (and `cor_mat()`) no longer emit the tidyselect "Using an external vector in selections was deprecated" warning when `vars`/`vars2` are passed as character vectors (e.g. `cor_test(data, vars = my_vars)`); the columns are now selected via `all_of()`. Bare names and tidyselect helpers are unaffected ([#202](https://github.com/kassambara/rstatix/issues/202)).
 - `p_format()` no longer strips a trailing `0` from the exponent of scientific-notation p-values (e.g. `p_format(5.1e-10)` returned `"5.1e-1"`; it now correctly returns `"5.1e-10"`). Ordinary decimal formatting, including `trailing.zero` padding, is unchanged ([#112](https://github.com/kassambara/rstatix/issues/112)).
 - `p_mark_significant()` no longer produces `"e-NA"` (with a coercion warning) when given a scientific-notation p-value string such as the output of `p_format()` on `1e-4`; it now correctly returns e.g. `"1e-04****"` ([#148](https://github.com/kassambara/rstatix/issues/148)).
 - `get_y_position()`/`add_y_position()` now space significance brackets by exactly `step.increase`. Previously the gap between consecutive brackets was `step.increase * n/(n-1)` (wider than requested) for `n >= 2` comparisons. **This changes the computed `y.position` values for plots with 3 or more groups** (brackets are slightly closer together); single-comparison (two-group) plots and `ref.group = "all"` are unchanged ([#201](https://github.com/kassambara/rstatix/issues/201)).

--- a/R/anova_test.R
+++ b/R/anova_test.R
@@ -92,19 +92,29 @@ NULL
 #'  list holding the arguments used to fit the ANOVA model, including: data, dv,
 #'  within, between, type, model, etc.
 #'
-#'@details The setting in \code{anova_test()} is done in such a way that it
-#'  gives the same results as SPSS, one of the most used commercial software. By
-#'  default, R uses treatment contrasts, where each of the levels is compared to
-#'  the first level used as baseline. The default contrast can be checked using
-#'  \code{options('contrasts')}. In the function \code{anova_test()}, the
-#'  following setting is used
-#'  \code{options(contrasts=c('contr.sum','contr.poly'))}, which gives
-#'  orthogonal contrasts where you compare every level to the overall mean. This
-#'  setting gives the same output as the most commonly used commercial
-#'  softwares, like SPSS. If you want to obtain the same result with the
-#'  function \code{car::Anova()} as the one obtained with
-#'  \code{rstatix::anova_test()}, then don't forget to set
-#'  \code{options(contrasts=c('contr.sum','contr.poly'))}.
+#'@details \strong{Contrasts}. By default, R uses treatment contrasts
+#'  (\code{contr.treatment}), where each factor level is compared to the first
+#'  level used as baseline; the current setting can be checked with
+#'  \code{options('contrasts')}.
+#'
+#'  How \code{anova_test()} handles contrasts depends on the interface you use:
+#'  \itemize{ \item When you use the \strong{formula interface} (or the \code{dv}
+#'  + \code{between}/\code{within} arguments), \code{anova_test()} fits the model
+#'  internally with \code{options(contrasts = c('contr.sum', 'contr.poly'))},
+#'  restoring your global option afterwards. This gives orthogonal contrasts,
+#'  where every level is compared to the overall mean, and type-III results that
+#'  match the most commonly used commercial softwares, like SPSS. \item When you
+#'  instead pass a \strong{pre-fitted model} (\code{lm()} or \code{aov()}),
+#'  \code{anova_test()} does not change its contrasts: the model keeps whatever
+#'  contrasts were in effect when it was fitted (R's default
+#'  \code{contr.treatment} unless you set otherwise). Fitting with the default
+#'  treatment contrasts and then requesting \code{type = 3} can therefore give
+#'  different results from the formula interface. }
+#'
+#'  To reproduce the formula-interface (SPSS) result from a pre-fitted model, or
+#'  to obtain the same result with \code{car::Anova()} directly, set
+#'  \code{options(contrasts = c('contr.sum', 'contr.poly'))} \emph{before}
+#'  fitting the model and use \code{type = 3}.
 #'@author Alboukadel Kassambara, \email{alboukadel.kassambara@@gmail.com}
 #' @examples
 #' # Load data

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -200,9 +200,23 @@ get_quo_vars <- function (data, vars)
   if(rlang::quo_is_missing(vars)){
     return(NULL)
   }
-  names(data) %>%
-    tidyselect::vars_select(!!vars) %>%
-    magrittr::set_names(NULL)
+  # A bare symbol that names a column is selected directly (original path), so a
+  # same-named object in the caller's environment can never shadow the column.
+  # Otherwise, if the expression resolves to a character vector (an external
+  # vector passed via vars =/vars2 =), select it with all_of() to avoid the
+  # tidyselect external-vector deprecation. Everything else (tidyselect helpers,
+  # numeric positions, ...) keeps the original byte-identical path (#202).
+  expr <- rlang::quo_get_expr(vars)
+  is.bare.column <- is.symbol(expr) && (rlang::as_string(expr) %in% names(data))
+  if(!is.bare.column){
+    resolved <- tryCatch(rlang::eval_tidy(vars), error = function(e) NULL)
+    if(is.character(resolved)){
+      selected <- tidyselect::vars_select(names(data), tidyselect::all_of(resolved))
+      return(magrittr::set_names(selected, NULL))
+    }
+  }
+  selected <- names(data) %>% tidyselect::vars_select(!!vars)
+  magrittr::set_names(selected, NULL)
 }
 # .args <- rlang::enquos(x = x, y = y, ...) %>%
 #   get_quo_vars_list(data, .)

--- a/man/anova_test.Rd
+++ b/man/anova_test.Rd
@@ -136,19 +136,29 @@ Provides a pipe-friendly framework to perform different types of
  checks.
 }
 \details{
-The setting in \code{anova_test()} is done in such a way that it
- gives the same results as SPSS, one of the most used commercial software. By
- default, R uses treatment contrasts, where each of the levels is compared to
- the first level used as baseline. The default contrast can be checked using
- \code{options('contrasts')}. In the function \code{anova_test()}, the
- following setting is used
- \code{options(contrasts=c('contr.sum','contr.poly'))}, which gives
- orthogonal contrasts where you compare every level to the overall mean. This
- setting gives the same output as the most commonly used commercial
- softwares, like SPSS. If you want to obtain the same result with the
- function \code{car::Anova()} as the one obtained with
- \code{rstatix::anova_test()}, then don't forget to set
- \code{options(contrasts=c('contr.sum','contr.poly'))}.
+\strong{Contrasts}. By default, R uses treatment contrasts
+ (\code{contr.treatment}), where each factor level is compared to the first
+ level used as baseline; the current setting can be checked with
+ \code{options('contrasts')}.
+
+ How \code{anova_test()} handles contrasts depends on the interface you use:
+ \itemize{ \item When you use the \strong{formula interface} (or the \code{dv}
+ + \code{between}/\code{within} arguments), \code{anova_test()} fits the model
+ internally with \code{options(contrasts = c('contr.sum', 'contr.poly'))},
+ restoring your global option afterwards. This gives orthogonal contrasts,
+ where every level is compared to the overall mean, and type-III results that
+ match the most commonly used commercial softwares, like SPSS. \item When you
+ instead pass a \strong{pre-fitted model} (\code{lm()} or \code{aov()}),
+ \code{anova_test()} does not change its contrasts: the model keeps whatever
+ contrasts were in effect when it was fitted (R's default
+ \code{contr.treatment} unless you set otherwise). Fitting with the default
+ treatment contrasts and then requesting \code{type = 3} can therefore give
+ different results from the formula interface. }
+
+ To reproduce the formula-interface (SPSS) result from a pre-fitted model, or
+ to obtain the same result with \code{car::Anova()} directly, set
+ \code{options(contrasts = c('contr.sum', 'contr.poly'))} \emph{before}
+ fitting the model and use \code{type = 3}.
 }
 \section{Functions}{
 \itemize{

--- a/tests/testthat/test-cor_test.R
+++ b/tests/testthat/test-cor_test.R
@@ -1,0 +1,66 @@
+context("test-cor_test")
+
+test_that("cor_test with external character vectors does not warn (deprecation) (#202)", {
+  # force lifecycle deprecations to always warn (not once-per-session)
+  rlang::local_options(lifecycle_verbosity = "warning")
+  matrix_vars  <- c("mpg", "disp")
+  matrix_vars2 <- c("hp", "wt")
+  w <- capture_warnings(
+    res <- cor_test(mtcars, vars = matrix_vars, vars2 = matrix_vars2)
+  )
+  expect_false(any(grepl("external vector", w)))   # the tidyselect deprecation is gone
+  expect_equal(nrow(res), 4L)                       # 2 vars x 2 vars2
+  expect_equal(res$var1, c("mpg", "mpg", "disp", "disp"))
+  expect_equal(res$var2, c("hp", "wt", "hp", "wt"))
+
+  # inline character vectors behave the same
+  w2 <- capture_warnings(
+    res2 <- cor_test(mtcars, vars = c("mpg", "disp"), vars2 = c("hp", "wt"))
+  )
+  expect_false(any(grepl("external vector", w2)))
+  expect_equal(res2[, c("var1", "var2")], res[, c("var1", "var2")])
+})
+
+test_that("cor_test selection is unchanged for bare names and tidyselect helpers (#202)", {
+  # bare names
+  bare <- cor_test(mtcars, mpg, disp)
+  expect_equal(nrow(bare), 1L)
+  expect_equal(c(bare$var1, bare$var2), c("mpg", "disp"))
+  # external character vector selects exactly the same variables as bare names
+  v <- cor_test(mtcars, vars = c("mpg", "disp"))
+  expect_equal(sort(unique(c(v$var1, v$var2))), sort(c("disp", "mpg")))
+  # tidyselect helper still works
+  helper <- cor_test(mtcars, dplyr::starts_with("d"))
+  expect_setequal(unique(c(helper$var1, helper$var2)), c("disp", "drat"))
+})
+
+test_that("get_quo_vars: a bare column name is never shadowed by an env object (#202)", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+  df$grp  <- as.character(df$supp)
+  dose <- "supp"   # an env object that shadows the column name
+  # bare symbol must resolve to the COLUMN, not the env object
+  expect_equal(rstatix:::get_quo_vars(df, rlang::quo(dose)), "dose")
+  # bare character column resolves to its name (not its values)
+  expect_equal(rstatix:::get_quo_vars(df, rlang::quo(grp)), "grp")
+  # external character vector is still selected by name (the #202 path)
+  v <- c("len", "dose")
+  expect_equal(rstatix:::get_quo_vars(df, rlang::quo(v)), c("len", "dose"))
+})
+
+test_that("anova_test bare grouping var is not shadowed by an env object (#202)", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+  dose <- "supp"   # shadowing object in scope
+  res <- anova_test(df, dv = len, between = dose)
+  expect_true("dose" %in% res$Effect)
+  expect_false("supp" %in% res$Effect)
+})
+
+test_that("cor_mat with external character vectors does not warn (#202)", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  keep <- c("mpg", "disp", "hp")
+  w <- capture_warnings(res <- cor_mat(mtcars, vars = keep))
+  expect_false(any(grepl("external vector", w)))
+  expect_equal(res$rowname, keep)
+})


### PR DESCRIPTION
Two low-risk maintenance items.

## #202 — `cor_test()` tidyselect deprecation with character vectors
Passing `vars`/`vars2` as character vectors triggered the tidyselect warning *"Using an external vector in selections was deprecated in tidyselect 1.1.0. Please use `all_of()` or `any_of()` instead."* (which will eventually error).

```r
my_vars  <- c("mpg", "disp")
my_vars2 <- c("hp", "wt")
cor_test(mtcars, vars = my_vars, vars2 = my_vars2)   # no more warning
```

`get_quo_vars()` now selects character vectors via `all_of()`. A bare symbol that names a column keeps the original selection path, so an environment object of the same name can never shadow the column; bare names, tidyselect helpers (`starts_with()`, …) and numeric positions are unaffected. Also fixes the same warning in `cor_mat(vars = ...)`.

## #225 — clarify `?anova_test` contrasts documentation
The manual implied `anova_test()` *always* applies `contr.sum`. It does for the **formula / `dv` + `between`/`within` interface** (fitting internally with `contr.sum`, matching SPSS / type-III), but **not** for a **pre-fitted `lm()`/`aov()`**, which keeps its own contrasts (R's default `contr.treatment` unless set otherwise) — the source of the reporter's confusion. The `@details` section now states this explicitly, including how to reproduce the SPSS result from a pre-fitted model.

## No regression
The `vars`/`vars2` selection is byte-identical for every previously-working input (bare names, helpers, numeric, NULL); only character-vector inputs change, and only to drop the warning while selecting the same columns. #225 is documentation only. Added regression + no-regression tests (incl. the env-shadowing edge case); full suite green.
