### PR TITLE
Keep even bracket spacing after filtering test results in add_xy_position (#197)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 ## Bug fixes
 
+- `add_xy_position()`/`add_y_position()` now keep significance brackets evenly spaced after the test results have been **filtered** (e.g. to keep only significant comparisons). Previously the y positions were computed for the full comparison set and then joined onto the filtered rows, producing uneven spacing; they are now computed for exactly the comparisons present. Unfiltered results, `ref.group = "all"`, one-sample and grouped tests are unchanged ([#197](https://github.com/kassambara/rstatix/issues/197)).
+
 - `cor_test()` (and `cor_mat()`) no longer emit the tidyselect "Using an external vector in selections was deprecated" warning when `vars`/`vars2` are passed as character vectors (e.g. `cor_test(data, vars = my_vars)`); the columns are now selected via `all_of()`. Bare names and tidyselect helpers are unaffected ([#202](https://github.com/kassambara/rstatix/issues/202)).
 - `p_format()` no longer strips a trailing `0` from the exponent of scientific-notation p-values (e.g. `p_format(5.1e-10)` returned `"5.1e-1"`; it now correctly returns `"5.1e-10"`). Ordinary decimal formatting, including `trailing.zero` padding, is unchanged ([#112](https://github.com/kassambara/rstatix/issues/112)).
 - `p_mark_significant()` no longer produces `"e-NA"` (with a coercion warning) when given a scientific-notation p-value string such as the output of `p_format()` on `1e-4`; it now correctly returns e.g. `"1e-04****"` ([#148](https://github.com/kassambara/rstatix/issues/148)).

--- a/R/get_pvalue_position.R
+++ b/R/get_pvalue_position.R
@@ -187,6 +187,25 @@ add_y_position <- function(test, fun = "max", step.increase = 0.12,
   if(is.null(data) | is.null(formula)){
     stop("data and formula arguments should be specified.")
   }
+  # When no explicit comparisons were used, derive them from the test's own
+  # group1/group2 rows so that y positions are computed for exactly the
+  # comparisons present (e.g. after filtering the test) instead of for the full
+  # comparison set, which would otherwise produce uneven bracket spacing (#197).
+  # Restricted to the standard ungrouped pairwise case; grouped tests,
+  # ref.group = "all" and one-sample tests keep their existing behavior.
+  if(is.null(comparisons) && !is_grouped_df(data) && nrow(test) > 0 &&
+     all(c("group1", "group2") %in% colnames(test))){
+    is.special <- any(test$group1 %in% c("all", ".all.")) ||
+      any(test$group2 %in% c("null model"))
+    if(!is.special){
+      comparisons <- purrr::map2(
+        as.character(test$group1), as.character(test$group2), c
+      )
+      # name like get_comparisons() (V1, V2, ...) so the derived `groups`
+      # list-column is identical to the unfiltered/default path
+      names(comparisons) <- paste0("V", seq_along(comparisons))
+    }
+  }
   positions <- get_y_position(
     data = data, formula = formula, fun = fun,
     ref.group = ref.group, comparisons = comparisons,

--- a/tests/testthat/test-add_x_position.R
+++ b/tests/testthat/test-add_x_position.R
@@ -160,3 +160,33 @@ test_that("Grouped plots: test that add_x_position works with different number o
   expect_equal(stat.test$xmin, c(0.8, 1.8, 2.73, 2.73, 3.73, 3.73))
   expect_equal(stat.test$xmax, c(1.2, 2.2, 3, 3.27, 4, 4.27))
 })
+
+test_that("add_xy_position keeps even bracket spacing after filtering the test (#197)", {
+  set.seed(1)
+  d <- tibble::tibble(
+    A = rnorm(10, 1), B = rnorm(10, 1), c = rnorm(10, 3),
+    D = rnorm(10, 5), E = rnorm(10, 1)
+  ) %>%
+    tidyr::pivot_longer(dplyr::everything(), names_to = "group", values_to = "value")
+  tk <- d %>% tukey_hsd(value ~ group) %>% dplyr::filter(p.adj < 0.05)
+  filt <- tk %>% add_xy_position()
+  # consecutive brackets must be evenly spaced (was uneven before the fix)
+  expect_equal(length(unique(round(diff(filt$y.position), 6))), 1L)
+  # identical to explicitly setting the comparisons (the reported workaround)
+  wk <- tk %>% add_xy_position(comparisons = purrr::map2(tk$group1, tk$group2, c))
+  expect_equal(filt$y.position, wk$y.position)
+})
+
+test_that("add_xy_position y.position is unchanged for unfiltered/edge cases (#197 no-regression)", {
+  # unfiltered ungrouped pairwise
+  expect_equal(round((df %>% t_test(len ~ dose) %>% add_xy_position())$y.position, 3),
+               c(35.388, 36.876, 38.364))
+  # ref.group = "all"
+  expect_equal(round((df %>% t_test(len ~ dose, ref.group = "all") %>% add_xy_position())$y.position, 3),
+               c(22.988, 28.788, 35.388))
+  # grouped (fix is skipped; existing behavior preserved)
+  expect_equal(nrow(df %>% group_by(supp) %>% t_test(len ~ dose) %>% add_xy_position()), 6L)
+  # empty (zero-row) filtered input returns gracefully, no error (#197 edge)
+  empty <- df %>% t_test(len ~ dose) %>% dplyr::filter(p < 0) %>% add_xy_position()
+  expect_equal(nrow(empty), 0L)
+})


### PR DESCRIPTION
## Keep significance brackets evenly spaced after filtering the test (#197)

Filtering a test's rows before `add_xy_position()` (e.g. to keep only significant comparisons) produced **unevenly-spaced** brackets:

```r
data %>% tukey_hsd(value ~ group) %>%
  filter(p.adj < 0.05) %>%
  add_xy_position()
# before: diff(y.position) = 0.54, 1.07, 0.54, 1.07, ...  (uneven)
# after:  diff(y.position) = 0.54, 0.54, 0.54, ...        (even)
```

### Root cause
`add_y_position()` computed y positions for the **full** comparison set (derived from the data/formula) and then left-joined them onto the filtered rows — so the kept rows inherited positions spaced for the unfiltered set.

### Fix
When no explicit `comparisons` were used, the comparisons are now derived from the test's own `group1`/`group2` rows, so positions are computed for **exactly the comparisons present**. This matches the previously-needed manual workaround (`add_xy_position(comparisons = ...)`).

### Scope / no regression
- **Unfiltered output is byte-identical** to before (every column, including the `groups` list-column names) — verified across `t_test`/`wilcox_test`/`tukey_hsd`/`dunn_test` vs the previous code.
- The fix is **gated** to the standard ungrouped pairwise case; grouped tests, `ref.group = "all"`, and one-sample tests keep their existing behavior. An empty (zero-row) filtered input still returns gracefully.
- Full suite green (`FAIL 0 / WARN 0 / PASS 287`); `R CMD check --as-cran` clean (0 errors/0 warnings); ggpubr's full suite passes against this build (`FAIL 0 / PASS 404`).
