### PR TITLE
Add df column to cor_test() for the Pearson method (#107)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## New features
 
+- `cor_test()` now returns the degrees of freedom (`df`) for the Pearson method (e.g. to report `r(df) = …, p`); the column sits next to `statistic`. Spearman/Kendall (which have no df) and `cor_mat()`/`cor_pmat()` are unchanged ([#107](https://github.com/kassambara/rstatix/issues/107)).
 - `get_summary_stats()` can now report **skewness** and **kurtosis** (bias-corrected, type-2 estimator, matching `e1071`'s `type = 2`). They are opt-in via `show`, e.g. `get_summary_stats(data, x, show = c("mean", "sd", "skewness", "kurtosis"))`, and are not added to any default `type`, so existing output is unchanged ([#99](https://github.com/kassambara/rstatix/issues/99)).
 - `get_summary_stats()` gains a `digits` argument to control the number of decimal places (default 3); useful when summarizing very small values that would otherwise round to 0 ([#145](https://github.com/kassambara/rstatix/issues/145), [#186](https://github.com/kassambara/rstatix/issues/186), [#218](https://github.com/kassambara/rstatix/issues/218)).
 

--- a/R/cor_test.R
+++ b/R/cor_test.R
@@ -41,7 +41,8 @@ NULL
 #'@return return a data frame with the following columns: \itemize{ \item
 #'  \code{var1, var2}: the variables used in the correlation test. \item
 #'  \code{cor}: the correlation coefficient. \item \code{statistic}: Test
-#'  statistic used to compute the p-value. \item \code{p}: p-value. \item
+#'  statistic used to compute the p-value. \item \code{df}: the degrees of
+#'  freedom (Pearson method only). \item \code{p}: p-value. \item
 #'  \code{conf.low,conf.high}: Lower and upper bounds on a confidence interval.
 #'  \item \code{method}: the method used to compute the statistic.}
 #'@seealso \code{\link{cor_mat}()}, \code{\link{as_cor_mat}()}
@@ -181,14 +182,15 @@ mcor_test <- function(data, x, y, ...){
 # Tidy output for correlation test
 as_tidy_cor <- function(x){
 
-  estimate <- cor <- statistic <- p <-
+  estimate <- cor <- statistic <- df <- p <-
     conf.low <- conf.high <- method <- NULL
   res <- x %>%
     as_tidy_stat() %>%
     rename(cor = estimate) %>%
     mutate(cor = signif(cor, 2))
   if(res$method == "Pearson"){
-    res %>% select(cor, statistic, p, conf.low, conf.high, method)
+    # Pearson reports the degrees of freedom (n - 2); Spearman/Kendall do not (#107)
+    res %>% select(cor, statistic, df, p, conf.low, conf.high, method)
   }
   else {
     res %>% select(cor, statistic, p, method)

--- a/man/cor_test.Rd
+++ b/man/cor_test.Rd
@@ -63,7 +63,8 @@ variable names: \code{c(var1, var2)}.}
 return a data frame with the following columns: \itemize{ \item
  \code{var1, var2}: the variables used in the correlation test. \item
  \code{cor}: the correlation coefficient. \item \code{statistic}: Test
- statistic used to compute the p-value. \item \code{p}: p-value. \item
+ statistic used to compute the p-value. \item \code{df}: the degrees of
+ freedom (Pearson method only). \item \code{p}: p-value. \item
  \code{conf.low,conf.high}: Lower and upper bounds on a confidence interval.
  \item \code{method}: the method used to compute the statistic.}
 }

--- a/tests/testthat/test-cor_test.R
+++ b/tests/testthat/test-cor_test.R
@@ -1,5 +1,35 @@
 context("test-cor_test")
 
+test_that("cor_test reports df for Pearson (#107)", {
+  res <- mtcars %>% cor_test(mpg, wt)
+  expect_true("df" %in% colnames(res))
+  # the df column carries the name "df" (consistent with t_test's df column), so compare values
+  expect_equal(unname(res$df), as.integer(nrow(mtcars) - 2))                 # n - 2
+  expect_equal(unname(res$df), unname(as.integer(cor.test(mtcars$mpg, mtcars$wt)$parameter)))
+  # df sits next to statistic
+  expect_equal(colnames(res),
+               c("var1", "var2", "cor", "statistic", "df", "p",
+                 "conf.low", "conf.high", "method"))
+})
+
+test_that("cor_test has no df column for Spearman/Kendall (#107 no-regression)", {
+  expect_false("df" %in% colnames(mtcars %>% cor_test(mpg, wt, method = "spearman")))
+  expect_false("df" %in% colnames(mtcars %>% cor_test(mpg, wt, method = "kendall")))
+})
+
+test_that("grouped Pearson cor_test reports df per group (#107)", {
+  g <- iris %>% group_by(Species) %>% cor_test(Sepal.Width, Sepal.Length)
+  expect_true("df" %in% colnames(g))
+  expect_true(all(g$df == 48L))   # 50 per species - 2
+})
+
+test_that("cor_mat / cor_pmat are unaffected by the df column (#107 no-regression)", {
+  cm <- mtcars %>% cor_mat(mpg, disp, hp)
+  expect_false("df" %in% colnames(cm))
+  expect_equal(colnames(cm), c("rowname", "mpg", "disp", "hp"))
+  expect_true(is.data.frame(mtcars %>% cor_pmat(mpg, disp, hp)))
+})
+
 test_that("cor_test with external character vectors does not warn (deprecation) (#202)", {
   # force lifecycle deprecations to always warn (not once-per-session)
   rlang::local_options(lifecycle_verbosity = "warning")


### PR DESCRIPTION
## Add a `df` column to `cor_test()` (Pearson)

`cor_test()` now reports the degrees of freedom for the Pearson method — useful for reporting a correlation as `r(df) = …, p`.

```r
mtcars %>% cor_test(mpg, wt)
#> # A tibble: 1 x 9
#>   var1  var2    cor statistic    df        p conf.low conf.high method
#>   <chr> <chr> <dbl>     <dbl> <int>    <dbl>    <dbl>     <dbl> <chr>
#> 1 mpg   wt    -0.87     -9.56    30 1.29e-10   -0.934    -0.744 Pearson
```

### Scope / no regression
- `df` (= n − 2) is added only for **Pearson** (it already came out of `cor.test()$parameter`); it sits next to `statistic`. Existing Pearson column **values** are unchanged.
- **Spearman/Kendall** have no df and are byte-identical to before.
- `cor_mat()` / `cor_pmat()` / `as_cor_mat()` are unaffected — they reshape by column name (`cor_spread(value = "cor"/"p")`), so the new column is ignored.
- Works with grouped data (df per group) and multi-variable correlation.

Verified byte-identical for all non-Pearson paths vs the previous code; full suite green (`FAIL 0 / WARN 0 / PASS 298`); `R CMD check --as-cran` clean (0 errors/0 warnings); ggpubr's full suite passes against this build (`FAIL 0 / PASS 404`).
