### PR TITLE
Return McNemar statistic and df in pairwise_mcnemar_test (#122)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - `cor_test()` now returns the degrees of freedom (`df`) for the Pearson method (e.g. to report `r(df) = …, p`); the column sits next to `statistic`. Spearman/Kendall (which have no df) and `cor_mat()`/`cor_pmat()` are unchanged ([#107](https://github.com/kassambara/rstatix/issues/107)).
 - `get_summary_stats()` can now report **skewness** and **kurtosis** (bias-corrected, type-2 estimator, matching `e1071`'s `type = 2`). They are opt-in via `show`, e.g. `get_summary_stats(data, x, show = c("mean", "sd", "skewness", "kurtosis"))`, and are not added to any default `type`, so existing output is unchanged ([#99](https://github.com/kassambara/rstatix/issues/99)).
 - `get_summary_stats()` gains a `digits` argument to control the number of decimal places (default 3); useful when summarizing very small values that would otherwise round to 0 ([#145](https://github.com/kassambara/rstatix/issues/145), [#186](https://github.com/kassambara/rstatix/issues/186), [#218](https://github.com/kassambara/rstatix/issues/218)).
+- `pairwise_mcnemar_test()` now returns the McNemar chi-squared `statistic` and `df` columns for `type = "mcnemar"` (the default), as the documentation already described; they were previously dropped. The exact-binomial path (`type = "exact"`), `mcnemar_test()`, and the `p`/`p.adj` values are unchanged ([#122](https://github.com/kassambara/rstatix/issues/122)).
 
 ## Main changes
 

--- a/R/mcnemar_test.R
+++ b/R/mcnemar_test.R
@@ -27,6 +27,11 @@ NULL
 #'  p-value. \item \code{method}: the used statistical test. \item
 #'  \code{p.signif}: the significance level of p-values.}
 #'
+#'  For \code{pairwise_mcnemar_test()}, the \code{statistic} and \code{df}
+#'  columns are returned for \code{type = "mcnemar"} (the default); they are
+#'  omitted for \code{type = "exact"}, which is based on an exact binomial test
+#'  and has no chi-squared statistic or degrees of freedom.
+#'
 #'  The \strong{returned object has an attribute called args}, which is a list
 #'  holding the test arguments.
 #' @examples
@@ -112,16 +117,21 @@ pairwise_mcnemar_test <- function (data, formula, type = c("mcnemar", "exact"), 
     xtab <- stats::xtabs(~grp1+grp2, grps.data)
     if(type == "mcnemar"){
       results <- mcnemar_test(xtab, correct = correct)
+      # Keep the McNemar chi-squared statistic and df (#122): documented for the
+      # pairwise output but previously dropped.
+      cols.to.keep <- c("statistic", "df", "p", "method")
     }
     else if(type == "exact"){
-      # Get off-diagonal values
+      # Get off-diagonal values (avoid shadowing base::c())
       b <- xtab[2, 1]
-      c <- xtab[1, 2]
-      results <- binom_test(b, (b + c), p = 0.5, detailed = TRUE)
+      cc <- xtab[1, 2]
+      results <- binom_test(b, (b + cc), p = 0.5, detailed = TRUE)
+      # The exact binomial test has no chi-squared statistic / df.
+      cols.to.keep <- c("p", "method")
     }
     results %>%
       keep_only_tbl_df_classes() %>%
-      select(all_of(c("p", "method"))) %>%
+      select(all_of(cols.to.keep)) %>%
       add_columns(group1 = grps[1], group2 = grps[2], .before = "p")
   }
   # Convert outcome into factor, then spread.
@@ -136,7 +146,14 @@ pairwise_mcnemar_test <- function (data, formula, type = c("mcnemar", "exact"), 
     bind_rows() %>%
     adjust_pvalue("p", method = p.adjust.method) %>%
     add_significance("p.adj")
-  results [, c("group1", "group2", "p", "p.adj", "p.adj.signif", "method")] %>%
+  # The McNemar type carries the chi-squared statistic and df (#122); the exact
+  # binomial type does not.
+  final.cols <- if(type == "mcnemar"){
+    c("group1", "group2", "statistic", "df", "p", "p.adj", "p.adj.signif", "method")
+  } else {
+    c("group1", "group2", "p", "p.adj", "p.adj.signif", "method")
+  }
+  results [, final.cols] %>%
     set_attrs(args = args) %>%
     add_class(c("rstatix_test", test.class))
 }

--- a/man/mcnemar_test.Rd
+++ b/man/mcnemar_test.Rd
@@ -48,6 +48,11 @@ return a data frame with the following columns: \itemize{
  p-value. \item \code{method}: the used statistical test. \item
  \code{p.signif}: the significance level of p-values.}
 
+ For \code{pairwise_mcnemar_test()}, the \code{statistic} and \code{df}
+ columns are returned for \code{type = "mcnemar"} (the default); they are
+ omitted for \code{type = "exact"}, which is based on an exact binomial test
+ and has no chi-squared statistic or degrees of freedom.
+
  The \strong{returned object has an attribute called args}, which is a list
  holding the test arguments.
 }

--- a/tests/testthat/test-mcnemar_test.R
+++ b/tests/testthat/test-mcnemar_test.R
@@ -1,0 +1,67 @@
+context("test-mcnemar_test")
+
+# Demo data: 3 related treatments, binary outcome (from ?mcnemar_test)
+make_mcnemar_data <- function(){
+  mydata <- data.frame(
+    outcome = c(0,1,1,0,0,1,0,1,1,1,1,1,0,0,1,1,0,1,0,1,1,0,0,1,0,1,1,0,0,1),
+    treatment = gl(3, 1, 30, labels = LETTERS[1:3]),
+    participant = gl(10, 3, labels = letters[1:10])
+  )
+  mydata$outcome <- factor(
+    mydata$outcome, levels = c(1, 0), labels = c("success", "failure")
+  )
+  mydata
+}
+
+test_that("pairwise_mcnemar_test returns statistic and df for type='mcnemar' (#122)", {
+  res <- pairwise_mcnemar_test(make_mcnemar_data(), outcome ~ treatment | participant)
+  expect_true(all(c("statistic", "df") %in% colnames(res)))
+  expect_equal(
+    colnames(res),
+    c("group1", "group2", "statistic", "df", "p", "p.adj", "p.adj.signif", "method")
+  )
+  expect_equal(nrow(res), 3L)                 # 3 pairwise comparisons of 3 groups
+  expect_true(all(res$df == 1))               # McNemar chi-squared on a 2x2 table
+})
+
+test_that("pairwise_mcnemar_test statistic/df match per-pair mcnemar_test (#122)", {
+  mydata <- make_mcnemar_data()
+  res <- pairwise_mcnemar_test(mydata, outcome ~ treatment | participant)
+  wide <- tidyr::spread(
+    dplyr::mutate(mydata, outcome = as.factor(outcome)),
+    key = treatment, value = outcome
+  )
+  manual_pair <- function(g1, g2){
+    xt <- stats::xtabs(stats::as.formula(paste0("~", g1, "+", g2)), wide)
+    mcnemar_test(xt)
+  }
+  ab <- manual_pair("A", "B")
+  row <- res[res$group1 == "A" & res$group2 == "B", ]
+  expect_equal(row$statistic, ab$statistic)
+  expect_equal(row$df, ab$df)
+  expect_equal(row$p, ab$p)
+})
+
+test_that("pairwise_mcnemar_test type='exact' has no statistic/df (#122 no-regression)", {
+  res <- pairwise_mcnemar_test(
+    make_mcnemar_data(), outcome ~ treatment | participant, type = "exact"
+  )
+  expect_false(any(c("statistic", "df") %in% colnames(res)))
+  expect_equal(
+    colnames(res),
+    c("group1", "group2", "p", "p.adj", "p.adj.signif", "method")
+  )
+  expect_equal(unique(res$method), "Exact binomial test")
+})
+
+test_that("mcnemar_test (single, 2x2) is unchanged (#122 no-regression)", {
+  xtab <- as.table(rbind(c(25, 6), c(21, 10)))
+  res <- mcnemar_test(xtab)
+  expect_equal(
+    colnames(res),
+    c("n", "statistic", "df", "p", "p.signif", "method")
+  )
+  expect_equal(res$n, 62)
+  expect_equal(unname(res$df), 1)
+  expect_equal(unname(res$p), stats::mcnemar.test(xtab)$p.value)
+})


### PR DESCRIPTION
## What

`pairwise_mcnemar_test(type = "mcnemar")` now returns the McNemar chi-squared
`statistic` and degrees of freedom (`df`), which the documentation already
listed but the code dropped before returning.

```r
mydata <- data.frame(
  outcome = c(0,1,1,0,0,1,0,1,1,1,1,1,0,0,1,1,0,1,0,1,1,0,0,1,0,1,1,0,0,1),
  treatment = gl(3, 1, 30, labels = LETTERS[1:3]),
  participant = gl(10, 3, labels = letters[1:10]))
mydata$outcome <- factor(mydata$outcome, levels = c(1, 0),
                         labels = c("success", "failure"))

pairwise_mcnemar_test(mydata, outcome ~ treatment | participant)
#> # A tibble: 3 x 8
#>   group1 group2 statistic    df      p  p.adj p.adj.signif method
#>   <chr>  <chr>      <dbl> <dbl>  <dbl>  <dbl> <chr>        <chr>
#> 1 A      B           0.8      1 0.371  1      ns           McNemar test
#> 2 A      C           6.12     1 0.0133 0.0400 *            McNemar test
#> 3 B      C           3.2      1 0.0736 0.221  ns           McNemar test
```

## Non-regression

- **Additive only** for the default `type = "mcnemar"`: the new `statistic`/`df`
  columns are added; `group1`/`group2`/`p`/`p.adj`/`p.adj.signif`/`method`
  values are unchanged.
- `type = "exact"` (exact binomial, which has no chi-squared statistic or df) is
  **byte-identical** to before, as is `mcnemar_test()`.
- Verified with a column-value battery against `master` (exact type, single
  `mcnemar_test`, and the mcnemar shared columns all identical) and new
  regression + no-regression tests in `test-mcnemar_test.R`. Full test suite
  green in a clean `--vanilla` session; `R CMD check --as-cran` clean; ggpubr
  full suite unaffected (FAIL 0 / PASS 404).

Refs #122 (part 1 of 3: McNemar statistic + df)

