### PR TITLE
Restore anova_test class[2] for reverse-dependency compatibility (#283)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,7 @@
 - `tukey_hsd()` now respects `conf.level` (and other `TukeyHSD()` arguments) for the ungrouped data-frame interface; previously `...` was dropped so the confidence interval was always 95% ([#188](https://github.com/kassambara/rstatix/issues/188)).
 - `pairwise_binom_test_against_p()` no longer errors on an unnamed `x`; groups are auto-labelled `grp1`, `grp2`, … (named/table input is unchanged) ([#44](https://github.com/kassambara/rstatix/issues/44)).
 - Fixed a missing space in the `anova_test()` error message for single-level factors (now reads "Variable x has only one level") ([#137](https://github.com/kassambara/rstatix/issues/137)).
+- `anova_test()` results now carry `rstatix_test` as the **first** class, with the specific test class (`anova_test` / `grouped_anova_test`) in second position — matching every other rstatix test. The [#106](https://github.com/kassambara/rstatix/issues/106) dplyr/vctrs invariant (`rstatix_test` before `data.frame`) is preserved, but the earlier `c("anova_test", "rstatix_test", "data.frame")` order had shifted the specific class out of position 2, breaking reverse dependencies that dispatch on `class(x)[2]` (e.g. GimmeMyStats, GimmeMyPlot). `inherits()`, `print()`/`plot()` dispatch, dplyr verbs and ggpubr are unaffected.
 
 
 # rstatix 0.7.3

--- a/R/anova_test.R
+++ b/R/anova_test.R
@@ -239,8 +239,11 @@ anova_test <- function(data, formula, dv, wid, between, within, covariate, type 
     results
   }
   .append_anova_class <- function(x){
-    # rstatix_test must come before data.frame for dplyr/vctrs compatibility (#106)
-    class(x) <- c("anova_test", "rstatix_test", class(x))
+    # Class order contract: "rstatix_test" first (consistent with every other
+    # rstatix test, and required before "data.frame" for dplyr/vctrs, #106),
+    # then the specific test class in position 2 so downstream code keying on
+    # class()[2] keeps resolving to "anova" (revdep compatibility, #283).
+    class(x) <- c("rstatix_test", "anova_test", class(x))
     x
   }
 
@@ -257,7 +260,7 @@ anova_test <- function(data, formula, dv, wid, between, within, covariate, type 
     }
     results <- results %>% set_attrs(args = list(data = data))
     # rstatix_test must come before data.frame for dplyr/vctrs compatibility (#106)
-    class(results) <- c("grouped_anova_test", "rstatix_test", class(results))
+    class(results) <- c("rstatix_test", "grouped_anova_test", class(results))
   }
   else{
     results <- .anova_test(
@@ -300,7 +303,7 @@ get_anova_table_from_simple_test <- function(x, correction = "auto"){
   if(correction.method == "none"){
     res.aov <- x$ANOVA
     attr(res.aov, "args") <- attr(x, "args")
-    class(res.aov) <- c("anova_test", "rstatix_test", class(res.aov))
+    class(res.aov) <- c("rstatix_test", "anova_test", class(res.aov))
     return(res.aov)
   }
   # repeated/mixed design
@@ -333,7 +336,7 @@ get_anova_table_from_simple_test <- function(x, correction = "auto"){
     rownames(res.aov) <- 1:nrow(res.aov)
   }
   res.aov <- res.aov %>% set_attrs(args = .args)
-  class(res.aov) <- c("anova_test", "rstatix_test", class(res.aov))
+  class(res.aov) <- c("rstatix_test", "anova_test", class(res.aov))
   res.aov
 }
 

--- a/tests/testthat/test-anova_test.R
+++ b/tests/testthat/test-anova_test.R
@@ -132,6 +132,27 @@ test_that("anova_test results are dplyr-compatible: rstatix_test before data.fra
   expect_true(inherits(g, "grouped_anova_test"))
 })
 
+test_that("anova_test class contract: rstatix_test first, specific class at [2] (#283 revdep)", {
+  # Reverse dependencies (e.g. GimmeMyStats, GimmeMyPlot) dispatch on class()[2]
+  # (method <- sub('_test', '', class(x)[2])). The class vector must keep
+  # 'rstatix_test' first (dplyr/vctrs, #106) AND the specific test class at
+  # position 2, so class()[2] resolves to the test name -- do not silently
+  # reorder these again (that broke revdeps in the 1.0.0 pretest).
+  u <- ToothGrowth %>% anova_test(len ~ dose)
+  expect_identical(class(u), c("rstatix_test", "anova_test", "data.frame"))
+  expect_identical(class(u)[2], "anova_test")            # class[2] -> "anova"
+  # grouped output follows the same contract
+  g <- ToothGrowth %>% group_by(supp) %>% anova_test(len ~ dose)
+  expect_identical(class(g)[1], "rstatix_test")
+  expect_identical(class(g)[2], "grouped_anova_test")
+  # #106 invariant restated: rstatix_test strictly before data.frame
+  expect_lt(match("rstatix_test", class(u)), match("data.frame", class(u)))
+  # the exact downstream idiom must resolve to the intended method
+  method <- sub("_test", "", class(u)[2])
+  method <- ifelse(method == "data.frame", "anova", method)
+  expect_identical(method, "anova")
+})
+
 test_that("add_xy_position on an anova_test gives an informative error, not a class error (#111)", {
   g <- ToothGrowth %>% group_by(supp) %>% anova_test(len ~ dose)
   # omnibus ANOVA has no pairwise comparisons: needs a pairwise post-hoc instead


### PR DESCRIPTION
CRAN's 1.0.0 reverse-dependency pretest flagged **GimmeMyStats** and **GimmeMyPlot** failing with `object 'index' not found`. Both format an rstatix test result by dispatching on `class(x)[2]`:

```r
method <- sub('_test', '', class(x)[2])
method <- ifelse(method == 'data.frame', 'anova', method)
```

The #106 dplyr/vctrs fix had reordered `anova_test()` output to `c('anova_test', 'rstatix_test', 'data.frame')`, pushing the specific class out of position 2, so `class(x)[2]` became `'rstatix_test'` and the downstream dispatch fell through.

## Fix
Reorder to `c('rstatix_test', 'anova_test', 'data.frame')` (and the grouped equivalent) — `rstatix_test` **first** (consistent with every other rstatix test, still before `data.frame` for #106), specific class back at position 2.

Verified against the packages' own code (with the fixed rstatix):
- `GimmeMyStats::print_test(anova)` → `Anova, F(1, 58) = 105, p < 0.001***` (was: error)
- `GimmeMyPlot::print_mean_test(anova)` → `Anova, F(1, 58) = 105.1, p < 0.001***`
- `inherits()`, `print()`/`plot().anova_test`, dplyr `filter`/`mutate` (#106), and ggpubr all unaffected (they use `inherits()`, order-independent).

## Tests
Added a class-contract regression test locking the exact class vector + `class[2]` for ungrouped and grouped `anova_test`; it fails under the old order. Full suite: **729 PASS / 0 fail** (clean `--vanilla` session). A fresh adversarial review confirmed S3 dispatch, internal code, #106 invariant, completeness (RM/mixed/welch/`get_anova_table`) and CRAN parity are all safe.

## Not addressed here (expected)
**microdiluteR**'s pretest failure is the documented full-precision p-value change (#108): its test hard-codes `0.0156`, now `0.015625`. That is the intended major-version behaviour; the downstream maintainer should use a tolerance.

Refs #283.