### PR TITLE
Add parallel options for bootstrap confidence intervals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
     emmeans,
     coin,
     boot,
-    testthat,
+    testthat (>= 3.1.7),
     spelling
 URL: https://rpkgs.datanovia.com/rstatix/
 BugReports: https://github.com/kassambara/rstatix/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rstatix 1.0.0.999
 
+## Minor changes
+
+- `cohens_d()`, `wilcox_effsize()`, `kruskal_effsize()` and `friedman_effsize()` gain `boot.parallel` and `boot.ncpus` arguments to compute the bootstrap confidence interval (`ci = TRUE`) in parallel, for example `cohens_d(df, len ~ supp, ci = TRUE, boot.parallel = "multicore", boot.ncpus = 4)`. They default to `getOption("boot.parallel", "no")` and `getOption("boot.ncpus", 1L)`, so the bootstrap stays serial by default, the corresponding global options keep working, and all existing results are unchanged. The parallel settings are now passed to `boot::boot()`, which performs the resampling, rather than to `boot::boot.ci()`, which has no such argument and silently ignored them. Based on the contribution by @HannesOberreiter ([#289](https://github.com/kassambara/rstatix/pull/289), [#87](https://github.com/kassambara/rstatix/pull/87)).
+
 
 # rstatix 1.0.0
 

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -79,7 +79,8 @@ NULL
 #'@export
 cohens_d <- function(data, formula, comparisons = NULL, ref.group = NULL, paired = FALSE, mu = 0,
                      var.equal = FALSE, hedges.correction = FALSE,
-                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000){
+                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
+                     parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
   env <- as.list(environment())
   args <- env %>% .add_item(method = "cohens_d")
   params <- env %>%
@@ -111,7 +112,8 @@ cohens_d <- function(data, formula, comparisons = NULL, ref.group = NULL, paired
 # Cohens d core function -------------------------------
 cohens.d <- function(x, y = NULL, mu = 0, paired = FALSE, var.equal = FALSE,
                      hedges.correction = FALSE,
-                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...){
+                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
+                     parallel = "no", ncpus = getOption("boot.ncpus", 1L), ...){
   check_two_samples_test_args(
     x = x, y = y, mu = mu, paired = paired,
     conf.level = conf.level
@@ -166,7 +168,7 @@ cohens.d <- function(x, y = NULL, mu = 0, paired = FALSE, var.equal = FALSE,
     }
     CI <- get_boot_ci(
       data, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot
+      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
     )
     results <- results %>% mutate(conf.low = CI[1], conf.high = CI[2])
   }

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -80,9 +80,15 @@ NULL
 cohens_d <- function(data, formula, comparisons = NULL, ref.group = NULL, paired = FALSE, mu = 0,
                      var.equal = FALSE, hedges.correction = FALSE,
                      ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                     parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                     boot.parallel = getOption("boot.parallel", "no"),
+                     boot.ncpus = getOption("boot.ncpus", 1L)){
   env <- as.list(environment())
-  args <- env %>% .add_item(method = "cohens_d")
+  # boot.parallel/boot.ncpus only steer how the bootstrap is computed, never the
+  # result, and their defaults depend on the user's options(); keep them out of
+  # the stashed args so attr(x, "args") stays deterministic.
+  args <- env %>%
+    remove_item(c("boot.parallel", "boot.ncpus")) %>%
+    .add_item(method = "cohens_d")
   params <- env %>%
     remove_null_items() %>%
     add_item(method = "cohens.d", detailed = FALSE)
@@ -113,7 +119,8 @@ cohens_d <- function(data, formula, comparisons = NULL, ref.group = NULL, paired
 cohens.d <- function(x, y = NULL, mu = 0, paired = FALSE, var.equal = FALSE,
                      hedges.correction = FALSE,
                      ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...,
-                     parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                     boot.parallel = getOption("boot.parallel", "no"),
+                     boot.ncpus = getOption("boot.ncpus", 1L)){
   check_two_samples_test_args(
     x = x, y = y, mu = mu, paired = paired,
     conf.level = conf.level
@@ -168,7 +175,7 @@ cohens.d <- function(x, y = NULL, mu = 0, paired = FALSE, var.equal = FALSE,
     }
     CI <- get_boot_ci(
       data, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
+      type = ci.type, nboot = nboot, parallel = boot.parallel, ncpus = boot.ncpus
     )
     results <- results %>% mutate(conf.low = CI[1], conf.high = CI[2])
   }

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -112,8 +112,8 @@ cohens_d <- function(data, formula, comparisons = NULL, ref.group = NULL, paired
 # Cohens d core function -------------------------------
 cohens.d <- function(x, y = NULL, mu = 0, paired = FALSE, var.equal = FALSE,
                      hedges.correction = FALSE,
-                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                     parallel = "no", ncpus = getOption("boot.ncpus", 1L), ...){
+                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...,
+                     parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
   check_two_samples_test_args(
     x = x, y = y, mu = mu, paired = paired,
     conf.level = conf.level

--- a/R/friedman_effsize.R
+++ b/R/friedman_effsize.R
@@ -45,20 +45,27 @@ NULL
 
 #' @export
 friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                             ..., parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                             ...,
+                             boot.parallel = getOption("boot.parallel", "no"),
+                             boot.ncpus = getOption("boot.ncpus", 1L)){
+  # See cohens_d(): the bootstrap-execution arguments are not part of the
+  # statistical call, so they are excluded from the stashed args.
   args <- as.list(environment()) %>%
+    remove_item(c("boot.parallel", "boot.ncpus")) %>%
     .add_item(method = "friedman_effsize")
   if(is_grouped_df(data)){
     results <- data %>%
       doo(
         .friedman_effsize, formula, ci = ci, conf.level = conf.level,
-        ci.type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus, ...
+        ci.type = ci.type, nboot = nboot,
+        boot.parallel = boot.parallel, boot.ncpus = boot.ncpus, ...
       )
   }
   else{
     results <- .friedman_effsize(
       data, formula, ci = ci, conf.level = conf.level,
-      ci.type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus, ...
+      ci.type = ci.type, nboot = nboot,
+      boot.parallel = boot.parallel, boot.ncpus = boot.ncpus, ...
     )
   }
   results %>%
@@ -68,7 +75,9 @@ friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.t
 
 
 .friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                              ..., parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                              ...,
+                              boot.parallel = getOption("boot.parallel", "no"),
+                              boot.ncpus = getOption("boot.ncpus", 1L)){
   results <- kendall_w(data, formula, ...)
   # Confidence interval of the effect size
   if (ci == TRUE) {
@@ -87,7 +96,7 @@ friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.t
     }
     CI <- get_boot_ci(
       data.wide, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
+      type = ci.type, nboot = nboot, parallel = boot.parallel, ncpus = boot.ncpus
     )
     results <- results %>%
       add_columns(conf.low = CI[1], conf.high = CI[2], .after = "effsize")

--- a/R/friedman_effsize.R
+++ b/R/friedman_effsize.R
@@ -44,20 +44,21 @@ NULL
 #' df %>% friedman_effsize(len ~ dose | id)
 
 #' @export
-friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...){
+friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
+                             parallel = "no", ncpus = getOption("boot.ncpus", 1L), ...){
   args <- as.list(environment()) %>%
     .add_item(method = "friedman_effsize")
   if(is_grouped_df(data)){
     results <- data %>%
       doo(
         .friedman_effsize, formula, ci = ci, conf.level = conf.level,
-        ci.type = ci.type, nboot = nboot, ...
+        ci.type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus, ...
       )
   }
   else{
     results <- .friedman_effsize(
       data, formula, ci = ci, conf.level = conf.level,
-      ci.type = ci.type, nboot = nboot, ...
+      ci.type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus, ...
     )
   }
   results %>%
@@ -66,7 +67,8 @@ friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.t
 }
 
 
-.friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...){
+.friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
+                              parallel = "no", ncpus = getOption("boot.ncpus", 1L), ...){
   results <- kendall_w(data, formula, ...)
   # Confidence interval of the effect size
   if (ci == TRUE) {
@@ -85,7 +87,7 @@ friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.t
     }
     CI <- get_boot_ci(
       data.wide, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot
+      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
     )
     results <- results %>%
       add_columns(conf.low = CI[1], conf.high = CI[2], .after = "effsize")

--- a/R/friedman_effsize.R
+++ b/R/friedman_effsize.R
@@ -45,7 +45,7 @@ NULL
 
 #' @export
 friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                             parallel = "no", ncpus = getOption("boot.ncpus", 1L), ...){
+                             ..., parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
   args <- as.list(environment()) %>%
     .add_item(method = "friedman_effsize")
   if(is_grouped_df(data)){
@@ -68,7 +68,7 @@ friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.t
 
 
 .friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                              parallel = "no", ncpus = getOption("boot.ncpus", 1L), ...){
+                              ..., parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
   results <- kendall_w(data, formula, ...)
   # Confidence interval of the effect size
   if (ci == TRUE) {

--- a/R/kruskal_effesize.R
+++ b/R/kruskal_effesize.R
@@ -52,20 +52,26 @@ NULL
 #'   kruskal_effsize(len ~ dose)
 #' @export
 kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                            parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                            boot.parallel = getOption("boot.parallel", "no"),
+                            boot.ncpus = getOption("boot.ncpus", 1L)){
+  # See cohens_d(): the bootstrap-execution arguments are not part of the
+  # statistical call, so they are excluded from the stashed args.
   args <- as.list(environment()) %>%
+    remove_item(c("boot.parallel", "boot.ncpus")) %>%
     .add_item(method = "kruskal_effsize")
   data %>%
     doo(
       .kruskal_effsize, formula, ci = ci, conf.level = conf.level,
-      ci.type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
+      ci.type = ci.type, nboot = nboot,
+      boot.parallel = boot.parallel, boot.ncpus = boot.ncpus
     ) %>%
     set_attrs(args = args) %>%
     add_class(c("rstatix_test", "kruskal_effsize"))
 }
 
 .kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                              parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                             boot.parallel = getOption("boot.parallel", "no"),
+                             boot.ncpus = getOption("boot.ncpus", 1L)){
   results <- eta_squared_h(data, formula)
   # Confidence interval of the effect size r
   if (ci == TRUE) {
@@ -74,7 +80,7 @@ kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.ty
     }
     CI <- get_boot_ci(
       data, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
+      type = ci.type, nboot = nboot, parallel = boot.parallel, ncpus = boot.ncpus
     )
     results <- results %>%
       add_columns(conf.low = CI[1], conf.high = CI[2], .after = "effsize")

--- a/R/kruskal_effesize.R
+++ b/R/kruskal_effesize.R
@@ -51,19 +51,21 @@ NULL
 #'   group_by(supp) %>%
 #'   kruskal_effsize(len ~ dose)
 #' @export
-kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000){
+kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
+                            parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
   args <- as.list(environment()) %>%
     .add_item(method = "kruskal_effsize")
   data %>%
     doo(
       .kruskal_effsize, formula, ci = ci, conf.level = conf.level,
-      ci.type = ci.type, nboot = nboot
+      ci.type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
     ) %>%
     set_attrs(args = args) %>%
     add_class(c("rstatix_test", "kruskal_effsize"))
 }
 
-.kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000){
+.kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
+                              parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
   results <- eta_squared_h(data, formula)
   # Confidence interval of the effect size r
   if (ci == TRUE) {
@@ -72,7 +74,7 @@ kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.ty
     }
     CI <- get_boot_ci(
       data, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot
+      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
     )
     results <- results %>%
       add_columns(conf.low = CI[1], conf.high = CI[2], .after = "effsize")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -798,10 +798,11 @@ get_pairwise_comparison_methods <- function(){
 }
 
 # Bootstrap confidence intervals -------------------------
-get_boot_ci <- function(data, stat.func, conf.level = 0.95, type = "perc", nboot = 500){
+get_boot_ci <- function(data, stat.func, conf.level = 0.95, type = "perc", nboot = 500,
+                        parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
   required_package("boot")
-  Boot = boot::boot(data, stat.func, R = nboot)
-  BCI = boot::boot.ci(Boot, conf = conf.level, type = type, parallel = "multicore")
+  Boot = boot::boot(data, stat.func, R = nboot, parallel = parallel, ncpus = ncpus)
+  BCI = boot::boot.ci(Boot, conf = conf.level, type = type)
   type <- switch(
     type, norm = "normal", perc = "percent",
     basic = "basic", bca = "bca", stud = "student", type

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -799,8 +799,12 @@ get_pairwise_comparison_methods <- function(){
 
 # Bootstrap confidence intervals -------------------------
 get_boot_ci <- function(data, stat.func, conf.level = 0.95, type = "perc", nboot = 500,
-                        parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                        parallel = getOption("boot.parallel", "no"),
+                        ncpus = getOption("boot.ncpus", 1L)){
   required_package("boot")
+  # boot::boot() resolves getOption("boot.parallel") only when `parallel` is
+  # missing; passing the option's own value keeps that behavior while allowing
+  # a per-call override. boot::boot.ci() has no `parallel` formal.
   Boot = boot::boot(data, stat.func, R = nboot, parallel = parallel, ncpus = ncpus)
   BCI = boot::boot.ci(Boot, conf = conf.level, type = type)
   type <- switch(

--- a/R/wilcox_effsize.R
+++ b/R/wilcox_effsize.R
@@ -40,9 +40,16 @@ NULL
 #'@param ci.type The type of confidence interval to use. Can be any of "norm",
 #'  "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.
 #'@param nboot The number of replications to use for bootstrap.
-#'@param parallel The type of parallel operation to be used for bootstrap.
-#'  Allowed values are "no", "multicore" and "snow".
-#'@param ncpus The number of processes to be used in parallel operation.
+#'@param boot.parallel The type of parallel operation to be used when computing
+#'  the bootstrap confidence interval. Allowed values are \code{"no"} (default),
+#'  \code{"multicore"} and \code{"snow"}. Passed to \code{\link[boot]{boot}()}.
+#'  Defaults to \code{getOption("boot.parallel", "no")}, so it can also be set
+#'  globally with \code{options(boot.parallel = "multicore")}. Only used when
+#'  \code{ci = TRUE}.
+#'@param boot.ncpus Integer. The number of processes to be used in the parallel
+#'  bootstrap. Defaults to \code{getOption("boot.ncpus", 1L)}. Note that
+#'  \code{boot.parallel} has no effect unless \code{boot.ncpus > 1}. Only used
+#'  when \code{ci = TRUE}.
 #'@param detailed logical value. Default is FALSE. If TRUE, the output
 #'  additionally includes the \code{Z} \code{statistic} (extracted from the
 #'  \code{coin} package and used to compute \code{r = Z/sqrt(N)}), the p-value
@@ -89,10 +96,15 @@ wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
                                 paired = FALSE, alternative = "two.sided",
                                 mu = 0, ci = FALSE, conf.level = 0.95, ci.type = "perc",
                                 nboot = 1000, detailed = FALSE, ...,
-                                parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                                boot.parallel = getOption("boot.parallel", "no"),
+                                boot.ncpus = getOption("boot.ncpus", 1L)){
 
   env <- as.list(environment())
-  args <- env %>% .add_item(method = "wilcox_effsize")
+  # See cohens_d(): the bootstrap-execution arguments are not part of the
+  # statistical call, so they are excluded from the stashed args.
+  args <- env %>%
+    remove_item(c("boot.parallel", "boot.ncpus")) %>%
+    .add_item(method = "wilcox_effsize")
   params <- c(env, list(...)) %>%
     remove_null_items() %>%
     add_item(method = "coin.wilcox.test", detailed = detailed)
@@ -122,7 +134,8 @@ wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
 # Wilcoxon test using coin R package; returns effect size
 coin.wilcox.test <- function(x, y = NULL, mu = 0, paired = FALSE, alternative = c("two.sided", "less", "greater"),
                      ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...,
-                     parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
+                     boot.parallel = getOption("boot.parallel", "no"),
+                     boot.ncpus = getOption("boot.ncpus", 1L)){
   required_package("coin")
 
   alternative <- match.arg(alternative)
@@ -178,7 +191,7 @@ coin.wilcox.test <- function(x, y = NULL, mu = 0, paired = FALSE, alternative = 
     }
     CI <- get_boot_ci(
       data, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
+      type = ci.type, nboot = nboot, parallel = boot.parallel, ncpus = boot.ncpus
       )
     results <- results %>% mutate(conf.low = CI[1], conf.high = CI[2])
   }

--- a/R/wilcox_effsize.R
+++ b/R/wilcox_effsize.R
@@ -88,9 +88,8 @@ NULL
 wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
                                 paired = FALSE, alternative = "two.sided",
                                 mu = 0, ci = FALSE, conf.level = 0.95, ci.type = "perc",
-                                nboot = 1000, parallel = "no",
-                                ncpus = getOption("boot.ncpus", 1L),
-                                detailed = FALSE, ...){
+                                nboot = 1000, detailed = FALSE, ...,
+                                parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
 
   env <- as.list(environment())
   args <- env %>% .add_item(method = "wilcox_effsize")
@@ -122,8 +121,8 @@ wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
 
 # Wilcoxon test using coin R package; returns effect size
 coin.wilcox.test <- function(x, y = NULL, mu = 0, paired = FALSE, alternative = c("two.sided", "less", "greater"),
-                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
-                     parallel = "no", ncpus = getOption("boot.ncpus", 1L), ...){
+                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...,
+                     parallel = "no", ncpus = getOption("boot.ncpus", 1L)){
   required_package("coin")
 
   alternative <- match.arg(alternative)

--- a/R/wilcox_effsize.R
+++ b/R/wilcox_effsize.R
@@ -40,6 +40,9 @@ NULL
 #'@param ci.type The type of confidence interval to use. Can be any of "norm",
 #'  "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.
 #'@param nboot The number of replications to use for bootstrap.
+#'@param parallel The type of parallel operation to be used for bootstrap.
+#'  Allowed values are "no", "multicore" and "snow".
+#'@param ncpus The number of processes to be used in parallel operation.
 #'@param detailed logical value. Default is FALSE. If TRUE, the output
 #'  additionally includes the \code{Z} \code{statistic} (extracted from the
 #'  \code{coin} package and used to compute \code{r = Z/sqrt(N)}), the p-value
@@ -85,7 +88,9 @@ NULL
 wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
                                 paired = FALSE, alternative = "two.sided",
                                 mu = 0, ci = FALSE, conf.level = 0.95, ci.type = "perc",
-                                nboot = 1000, detailed = FALSE, ...){
+                                nboot = 1000, parallel = "no",
+                                ncpus = getOption("boot.ncpus", 1L),
+                                detailed = FALSE, ...){
 
   env <- as.list(environment())
   args <- env %>% .add_item(method = "wilcox_effsize")
@@ -117,7 +122,8 @@ wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
 
 # Wilcoxon test using coin R package; returns effect size
 coin.wilcox.test <- function(x, y = NULL, mu = 0, paired = FALSE, alternative = c("two.sided", "less", "greater"),
-                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000, ...){
+                     ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
+                     parallel = "no", ncpus = getOption("boot.ncpus", 1L), ...){
   required_package("coin")
 
   alternative <- match.arg(alternative)
@@ -173,7 +179,7 @@ coin.wilcox.test <- function(x, y = NULL, mu = 0, paired = FALSE, alternative = 
     }
     CI <- get_boot_ci(
       data, stat.func, conf.level = conf.level,
-      type = ci.type, nboot = nboot
+      type = ci.type, nboot = nboot, parallel = parallel, ncpus = ncpus
       )
     results <- results %>% mutate(conf.low = CI[1], conf.high = CI[2])
   }

--- a/man/cohens_d.Rd
+++ b/man/cohens_d.Rd
@@ -16,7 +16,9 @@ cohens_d(
   ci = FALSE,
   conf.level = 0.95,
   ci.type = "perc",
-  nboot = 1000
+  nboot = 1000,
+  parallel = "no",
+  ncpus = getOption("boot.ncpus", 1L)
 )
 }
 \arguments{
@@ -65,6 +67,11 @@ n2).}
 "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.}
 
 \item{nboot}{The number of replications to use for bootstrap.}
+
+\item{parallel}{The type of parallel operation to be used for bootstrap.
+Allowed values are "no", "multicore" and "snow".}
+
+\item{ncpus}{The number of processes to be used in parallel operation.}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/man/cohens_d.Rd
+++ b/man/cohens_d.Rd
@@ -17,8 +17,8 @@ cohens_d(
   conf.level = 0.95,
   ci.type = "perc",
   nboot = 1000,
-  parallel = "no",
-  ncpus = getOption("boot.ncpus", 1L)
+  boot.parallel = getOption("boot.parallel", "no"),
+  boot.ncpus = getOption("boot.ncpus", 1L)
 )
 }
 \arguments{
@@ -68,10 +68,17 @@ n2).}
 
 \item{nboot}{The number of replications to use for bootstrap.}
 
-\item{parallel}{The type of parallel operation to be used for bootstrap.
-Allowed values are "no", "multicore" and "snow".}
+\item{boot.parallel}{The type of parallel operation to be used when computing
+the bootstrap confidence interval. Allowed values are \code{"no"} (default),
+\code{"multicore"} and \code{"snow"}. Passed to \code{\link[boot]{boot}()}.
+Defaults to \code{getOption("boot.parallel", "no")}, so it can also be set
+globally with \code{options(boot.parallel = "multicore")}. Only used when
+\code{ci = TRUE}.}
 
-\item{ncpus}{The number of processes to be used in parallel operation.}
+\item{boot.ncpus}{Integer. The number of processes to be used in the parallel
+bootstrap. Defaults to \code{getOption("boot.ncpus", 1L)}. Note that
+\code{boot.parallel} has no effect unless \code{boot.ncpus > 1}. Only used
+when \code{ci = TRUE}.}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/man/friedman_effsize.Rd
+++ b/man/friedman_effsize.Rd
@@ -12,8 +12,8 @@ friedman_effsize(
   ci.type = "perc",
   nboot = 1000,
   ...,
-  parallel = "no",
-  ncpus = getOption("boot.ncpus", 1L)
+  boot.parallel = getOption("boot.parallel", "no"),
+  boot.ncpus = getOption("boot.ncpus", 1L)
 )
 }
 \arguments{
@@ -35,10 +35,17 @@ individuals/subjects identifier. Should be unique per individual.}
 
 \item{...}{other arguments passed to the function \code{\link[stats]{friedman.test}()}}
 
-\item{parallel}{The type of parallel operation to be used for bootstrap.
-Allowed values are "no", "multicore" and "snow".}
+\item{boot.parallel}{The type of parallel operation to be used when computing
+the bootstrap confidence interval. Allowed values are \code{"no"} (default),
+\code{"multicore"} and \code{"snow"}. Passed to \code{\link[boot]{boot}()}.
+Defaults to \code{getOption("boot.parallel", "no")}, so it can also be set
+globally with \code{options(boot.parallel = "multicore")}. Only used when
+\code{ci = TRUE}.}
 
-\item{ncpus}{The number of processes to be used in parallel operation.}
+\item{boot.ncpus}{Integer. The number of processes to be used in the parallel
+bootstrap. Defaults to \code{getOption("boot.ncpus", 1L)}. Note that
+\code{boot.parallel} has no effect unless \code{boot.ncpus > 1}. Only used
+when \code{ci = TRUE}.}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/man/friedman_effsize.Rd
+++ b/man/friedman_effsize.Rd
@@ -11,6 +11,8 @@ friedman_effsize(
   conf.level = 0.95,
   ci.type = "perc",
   nboot = 1000,
+  parallel = "no",
+  ncpus = getOption("boot.ncpus", 1L),
   ...
 )
 }
@@ -30,6 +32,11 @@ individuals/subjects identifier. Should be unique per individual.}
 "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.}
 
 \item{nboot}{The number of replications to use for bootstrap.}
+
+\item{parallel}{The type of parallel operation to be used for bootstrap.
+Allowed values are "no", "multicore" and "snow".}
+
+\item{ncpus}{The number of processes to be used in parallel operation.}
 
 \item{...}{other arguments passed to the function \code{\link[stats]{friedman.test}()}}
 }

--- a/man/friedman_effsize.Rd
+++ b/man/friedman_effsize.Rd
@@ -11,9 +11,9 @@ friedman_effsize(
   conf.level = 0.95,
   ci.type = "perc",
   nboot = 1000,
+  ...,
   parallel = "no",
-  ncpus = getOption("boot.ncpus", 1L),
-  ...
+  ncpus = getOption("boot.ncpus", 1L)
 )
 }
 \arguments{
@@ -33,12 +33,12 @@ individuals/subjects identifier. Should be unique per individual.}
 
 \item{nboot}{The number of replications to use for bootstrap.}
 
+\item{...}{other arguments passed to the function \code{\link[stats]{friedman.test}()}}
+
 \item{parallel}{The type of parallel operation to be used for bootstrap.
 Allowed values are "no", "multicore" and "snow".}
 
 \item{ncpus}{The number of processes to be used in parallel operation.}
-
-\item{...}{other arguments passed to the function \code{\link[stats]{friedman.test}()}}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/man/kruskal_effsize.Rd
+++ b/man/kruskal_effsize.Rd
@@ -11,8 +11,8 @@ kruskal_effsize(
   conf.level = 0.95,
   ci.type = "perc",
   nboot = 1000,
-  parallel = "no",
-  ncpus = getOption("boot.ncpus", 1L)
+  boot.parallel = getOption("boot.parallel", "no"),
+  boot.ncpus = getOption("boot.ncpus", 1L)
 )
 }
 \arguments{
@@ -32,10 +32,17 @@ one or multiple levels giving the corresponding groups. For example,
 
 \item{nboot}{The number of replications to use for bootstrap.}
 
-\item{parallel}{The type of parallel operation to be used for bootstrap.
-Allowed values are "no", "multicore" and "snow".}
+\item{boot.parallel}{The type of parallel operation to be used when computing
+the bootstrap confidence interval. Allowed values are \code{"no"} (default),
+\code{"multicore"} and \code{"snow"}. Passed to \code{\link[boot]{boot}()}.
+Defaults to \code{getOption("boot.parallel", "no")}, so it can also be set
+globally with \code{options(boot.parallel = "multicore")}. Only used when
+\code{ci = TRUE}.}
 
-\item{ncpus}{The number of processes to be used in parallel operation.}
+\item{boot.ncpus}{Integer. The number of processes to be used in the parallel
+bootstrap. Defaults to \code{getOption("boot.ncpus", 1L)}. Note that
+\code{boot.parallel} has no effect unless \code{boot.ncpus > 1}. Only used
+when \code{ci = TRUE}.}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/man/kruskal_effsize.Rd
+++ b/man/kruskal_effsize.Rd
@@ -10,7 +10,9 @@ kruskal_effsize(
   ci = FALSE,
   conf.level = 0.95,
   ci.type = "perc",
-  nboot = 1000
+  nboot = 1000,
+  parallel = "no",
+  ncpus = getOption("boot.ncpus", 1L)
 )
 }
 \arguments{
@@ -29,6 +31,11 @@ one or multiple levels giving the corresponding groups. For example,
 "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.}
 
 \item{nboot}{The number of replications to use for bootstrap.}
+
+\item{parallel}{The type of parallel operation to be used for bootstrap.
+Allowed values are "no", "multicore" and "snow".}
+
+\item{ncpus}{The number of processes to be used in parallel operation.}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/man/wilcox_effsize.Rd
+++ b/man/wilcox_effsize.Rd
@@ -18,8 +18,8 @@ wilcox_effsize(
   nboot = 1000,
   detailed = FALSE,
   ...,
-  parallel = "no",
-  ncpus = getOption("boot.ncpus", 1L)
+  boot.parallel = getOption("boot.parallel", "no"),
+  boot.ncpus = getOption("boot.ncpus", 1L)
 )
 }
 \arguments{
@@ -71,10 +71,17 @@ and the underlying Z are reported together in one data frame.}
 \code{coin::wilcoxsign_test()} (case of one- or paired-samples test) or
 \code{coin::wilcox_test()} (case of independent two-samples test).}
 
-\item{parallel}{The type of parallel operation to be used for bootstrap.
-Allowed values are "no", "multicore" and "snow".}
+\item{boot.parallel}{The type of parallel operation to be used when computing
+the bootstrap confidence interval. Allowed values are \code{"no"} (default),
+\code{"multicore"} and \code{"snow"}. Passed to \code{\link[boot]{boot}()}.
+Defaults to \code{getOption("boot.parallel", "no")}, so it can also be set
+globally with \code{options(boot.parallel = "multicore")}. Only used when
+\code{ci = TRUE}.}
 
-\item{ncpus}{The number of processes to be used in parallel operation.}
+\item{boot.ncpus}{Integer. The number of processes to be used in the parallel
+bootstrap. Defaults to \code{getOption("boot.ncpus", 1L)}. Note that
+\code{boot.parallel} has no effect unless \code{boot.ncpus > 1}. Only used
+when \code{ci = TRUE}.}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/man/wilcox_effsize.Rd
+++ b/man/wilcox_effsize.Rd
@@ -16,6 +16,8 @@ wilcox_effsize(
   conf.level = 0.95,
   ci.type = "perc",
   nboot = 1000,
+  parallel = "no",
+  ncpus = getOption("boot.ncpus", 1L),
   detailed = FALSE,
   ...
 )
@@ -58,6 +60,11 @@ hypothesis.}
 "basic", "perc", or "bca". Passed to \code{boot::boot.ci}.}
 
 \item{nboot}{The number of replications to use for bootstrap.}
+
+\item{parallel}{The type of parallel operation to be used for bootstrap.
+Allowed values are "no", "multicore" and "snow".}
+
+\item{ncpus}{The number of processes to be used in parallel operation.}
 
 \item{detailed}{logical value. Default is FALSE. If TRUE, the output
 additionally includes the \code{Z} \code{statistic} (extracted from the

--- a/man/wilcox_effsize.Rd
+++ b/man/wilcox_effsize.Rd
@@ -16,10 +16,10 @@ wilcox_effsize(
   conf.level = 0.95,
   ci.type = "perc",
   nboot = 1000,
-  parallel = "no",
-  ncpus = getOption("boot.ncpus", 1L),
   detailed = FALSE,
-  ...
+  ...,
+  parallel = "no",
+  ncpus = getOption("boot.ncpus", 1L)
 )
 }
 \arguments{
@@ -61,11 +61,6 @@ hypothesis.}
 
 \item{nboot}{The number of replications to use for bootstrap.}
 
-\item{parallel}{The type of parallel operation to be used for bootstrap.
-Allowed values are "no", "multicore" and "snow".}
-
-\item{ncpus}{The number of processes to be used in parallel operation.}
-
 \item{detailed}{logical value. Default is FALSE. If TRUE, the output
 additionally includes the \code{Z} \code{statistic} (extracted from the
 \code{coin} package and used to compute \code{r = Z/sqrt(N)}), the p-value
@@ -75,6 +70,11 @@ and the underlying Z are reported together in one data frame.}
 \item{...}{Additional arguments passed to the functions
 \code{coin::wilcoxsign_test()} (case of one- or paired-samples test) or
 \code{coin::wilcox_test()} (case of independent two-samples test).}
+
+\item{parallel}{The type of parallel operation to be used for bootstrap.
+Allowed values are "no", "multicore" and "snow".}
+
+\item{ncpus}{The number of processes to be used in parallel operation.}
 }
 \value{
 return a data frame with some of the following columns: \itemize{

--- a/tests/testthat/test-bootstrap_ci.R
+++ b/tests/testthat/test-bootstrap_ci.R
@@ -1,0 +1,14 @@
+context("test-bootstrap_ci")
+
+test_that("get_boot_ci forwards parallel arguments to boot", {
+  skip_if_not_installed("boot")
+  stat_func <- function(data, i) mean(data$x[i])
+
+  expect_error(
+    get_boot_ci(
+      data.frame(x = 1:5), stat_func,
+      nboot = 10, parallel = "bad", ncpus = 1
+    ),
+    "should be one of"
+  )
+})

--- a/tests/testthat/test-bootstrap_ci.R
+++ b/tests/testthat/test-bootstrap_ci.R
@@ -1,14 +1,138 @@
 context("test-bootstrap_ci")
 
-test_that("get_boot_ci forwards parallel arguments to boot", {
+# A stand-in for boot::boot() that records how it was called and then aborts with
+# a distinctively classed condition, so the assertions never depend on a
+# translated error message (base R's match.arg() text is localized).
+mock_boot <- function(record) {
+  function(data, statistic, R, ..., parallel, ncpus) {
+    record$parallel <- parallel
+    record$ncpus <- ncpus
+    stop(structure(
+      class = c("mock_boot_called", "error", "condition"),
+      list(message = "mock boot::boot() called", call = NULL)
+    ))
+  }
+}
+
+stat_func <- function(data, i) mean(data$x[i])
+boot_data <- data.frame(x = 1:10)
+
+test_that("get_boot_ci forwards parallel and ncpus to boot::boot()", {
   skip_if_not_installed("boot")
-  stat_func <- function(data, i) mean(data$x[i])
+  record <- new.env()
+  local_mocked_bindings(boot = mock_boot(record), .package = "boot")
 
   expect_error(
-    get_boot_ci(
-      data.frame(x = 1:5), stat_func,
-      nboot = 10, parallel = "bad", ncpus = 1
-    ),
-    "should be one of"
+    get_boot_ci(boot_data, stat_func, nboot = 10, parallel = "multicore", ncpus = 3),
+    class = "mock_boot_called"
   )
+  expect_equal(record$parallel, "multicore")
+  expect_equal(record$ncpus, 3)
+})
+
+test_that("get_boot_ci honours options(boot.parallel=) and options(boot.ncpus=)", {
+  # Regression test: boot::boot() resolves getOption("boot.parallel") only when
+  # `parallel` is missing. Passing a hard-coded "no" silently disabled the option.
+  skip_if_not_installed("boot")
+  record <- new.env()
+  local_mocked_bindings(boot = mock_boot(record), .package = "boot")
+
+  old <- options(boot.parallel = "multicore", boot.ncpus = 2L)
+  on.exit(options(old), add = TRUE)
+
+  expect_error(
+    get_boot_ci(boot_data, stat_func, nboot = 10),
+    class = "mock_boot_called"
+  )
+  expect_equal(record$parallel, "multicore")
+  expect_equal(record$ncpus, 2L)
+})
+
+test_that("an explicit parallel argument overrides options(boot.parallel=)", {
+  skip_if_not_installed("boot")
+  record <- new.env()
+  local_mocked_bindings(boot = mock_boot(record), .package = "boot")
+
+  old <- options(boot.parallel = "multicore", boot.ncpus = 2L)
+  on.exit(options(old), add = TRUE)
+
+  expect_error(
+    get_boot_ci(boot_data, stat_func, nboot = 10, parallel = "no", ncpus = 1L),
+    class = "mock_boot_called"
+  )
+  expect_equal(record$parallel, "no")
+  expect_equal(record$ncpus, 1L)
+})
+
+test_that("get_boot_ci defaults to a serial bootstrap", {
+  skip_if_not_installed("boot")
+  record <- new.env()
+  local_mocked_bindings(boot = mock_boot(record), .package = "boot")
+
+  old <- options(boot.parallel = NULL, boot.ncpus = NULL)
+  on.exit(options(old), add = TRUE)
+
+  expect_error(
+    get_boot_ci(boot_data, stat_func, nboot = 10),
+    class = "mock_boot_called"
+  )
+  expect_equal(record$parallel, "no")
+  expect_equal(record$ncpus, 1L)
+})
+
+test_that("the effect size functions forward boot.parallel and boot.ncpus", {
+  skip_if_not_installed("boot")
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+
+  record <- new.env()
+  local_mocked_bindings(boot = mock_boot(record), .package = "boot")
+  expect_error(
+    cohens_d(df, len ~ supp, ci = TRUE, nboot = 10,
+             boot.parallel = "multicore", boot.ncpus = 3),
+    class = "mock_boot_called"
+  )
+  expect_equal(record$parallel, "multicore")
+  expect_equal(record$ncpus, 3)
+
+  record2 <- new.env()
+  local_mocked_bindings(boot = mock_boot(record2), .package = "boot")
+  expect_error(
+    kruskal_effsize(df, len ~ dose, ci = TRUE, nboot = 10,
+                    boot.parallel = "multicore", boot.ncpus = 3),
+    class = "mock_boot_called"
+  )
+  expect_equal(record2$parallel, "multicore")
+  expect_equal(record2$ncpus, 3)
+})
+
+test_that("boot.parallel and boot.ncpus are not stored in the test arguments", {
+  # attr(x, "args") records the statistical call (ggpubr reads it back via
+  # get_test_arguments()). The bootstrap-execution arguments cannot change any
+  # returned value, and their defaults depend on the user's options(), so
+  # including them would make the attribute vary between sessions.
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+
+  expect_false(any(c("boot.parallel", "boot.ncpus") %in%
+                     names(attr(cohens_d(df, len ~ supp), "args"))))
+  expect_false(any(c("boot.parallel", "boot.ncpus") %in%
+                     names(attr(kruskal_effsize(df, len ~ dose), "args"))))
+})
+
+test_that("the default bootstrap confidence interval is unchanged (no regression)", {
+  # Values pinned from the behaviour before the parallel arguments were added, so
+  # that a change to the bootstrap plumbing cannot move them silently.
+  skip_if_not_installed("boot")
+  df <- ToothGrowth
+
+  set.seed(42)
+  res <- cohens_d(df, len ~ supp, ci = TRUE, nboot = 200)
+  expect_equal(res$conf.low, -0.06)
+  expect_equal(res$conf.high, 1.2)
+
+  set.seed(42)
+  res2 <- cohens_d(df, len ~ supp, ci = TRUE, nboot = 200, ci.type = "basic")
+  expect_equal(res2$conf.low, -0.21)
+  expect_equal(res2$conf.high, 1.05)
 })

--- a/tests/testthat/test-bootstrap_ci.R
+++ b/tests/testthat/test-bootstrap_ci.R
@@ -106,6 +106,55 @@ test_that("the effect size functions forward boot.parallel and boot.ncpus", {
   expect_equal(record2$ncpus, 3)
 })
 
+test_that("the arguments placed after `...` also reach boot::boot()", {
+  # friedman_effsize() and wilcox_effsize() take boot.parallel/boot.ncpus after
+  # `...`, so they must be matched exactly rather than swallowed by the dots.
+  skip_if_not_installed("boot")
+
+  df <- data.frame(
+    id = factor(rep(1:8, each = 3)),
+    time = factor(rep(c("t1", "t2", "t3"), times = 8)),
+    score = c(12, 15, 18, 11, 14, 20, 13, 17, 19, 10, 16, 21,
+              14, 13, 22, 15, 12, 17, 11, 18, 20, 16, 14, 23)
+  )
+  record <- new.env()
+  local_mocked_bindings(boot = mock_boot(record), .package = "boot")
+  expect_error(
+    friedman_effsize(df, score ~ time | id, ci = TRUE, nboot = 10,
+                     boot.parallel = "multicore", boot.ncpus = 3),
+    class = "mock_boot_called"
+  )
+  expect_equal(record$parallel, "multicore")
+  expect_equal(record$ncpus, 3)
+
+  skip_if_not_installed("coin")
+  record2 <- new.env()
+  local_mocked_bindings(boot = mock_boot(record2), .package = "boot")
+  expect_error(
+    wilcox_effsize(ToothGrowth, len ~ supp, ci = TRUE, nboot = 10,
+                   boot.parallel = "multicore", boot.ncpus = 3),
+    class = "mock_boot_called"
+  )
+  expect_equal(record2$parallel, "multicore")
+  expect_equal(record2$ncpus, 3)
+})
+
+test_that("grouped data forward the bootstrap arguments for every group", {
+  skip_if_not_installed("boot")
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+
+  record <- new.env()
+  local_mocked_bindings(boot = mock_boot(record), .package = "boot")
+  expect_error(
+    kruskal_effsize(dplyr::group_by(df, supp), len ~ dose, ci = TRUE, nboot = 10,
+                    boot.parallel = "multicore", boot.ncpus = 3),
+    class = "mock_boot_called"
+  )
+  expect_equal(record$parallel, "multicore")
+  expect_equal(record$ncpus, 3)
+})
+
 test_that("boot.parallel and boot.ncpus are not stored in the test arguments", {
   # attr(x, "args") records the statistical call (ggpubr reads it back via
   # get_test_arguments()). The bootstrap-execution arguments cannot change any

--- a/tests/testthat/test-cohens_d.R
+++ b/tests/testthat/test-cohens_d.R
@@ -30,3 +30,18 @@ test_that("cohens_d default (mu = 0) is the standard Cohen's d (no regression, #
   os <- ToothGrowth %>% cohens_d(len ~ 1, mu = 20)
   expect_equal(as.numeric(os$effsize), (mean(ToothGrowth$len) - 20) / sd(ToothGrowth$len), tolerance = 1e-4)
 })
+
+test_that("cohens_d still accepts abbreviated argument names (no regression)", {
+  # The bootstrap arguments are named boot.parallel / boot.ncpus (not parallel /
+  # ncpus) so that `p`/`pa` keep partial-matching unambiguously to `paired`, and
+  # `n` to `nboot`.
+  diffs <- oj - vc
+  expect_equal(as.numeric(cohens_d(ToothGrowth, len ~ supp, p = TRUE)$effsize),
+               mean(diffs) / sd(diffs), tolerance = 1e-4)
+  expect_equal(as.numeric(cohens_d(ToothGrowth, len ~ supp, pa = TRUE)$effsize),
+               mean(diffs) / sd(diffs), tolerance = 1e-4)
+  skip_if_not_installed("boot")
+  set.seed(42)
+  res <- cohens_d(ToothGrowth, len ~ supp, ci = TRUE, n = 200)
+  expect_true(all(c("conf.low", "conf.high") %in% colnames(res)))
+})

--- a/tests/testthat/test-kruskal_effsize.R
+++ b/tests/testthat/test-kruskal_effsize.R
@@ -16,3 +16,14 @@ test_that("kruskal_effsize magnitude is unchanged for valid effect sizes (no reg
   expect_true(res$effsize > 0.14)
   expect_equal(as.character(res$magnitude), "large")
 })
+
+test_that("kruskal_effsize accepts bootstrap parallel options", {
+  skip_if_not_installed("boot")
+  set.seed(123)
+
+  res <- ToothGrowth %>%
+    kruskal_effsize(len ~ dose, ci = TRUE, nboot = 50, parallel = "no", ncpus = 1)
+
+  expect_true(all(c("conf.low", "conf.high") %in% colnames(res)))
+  expect_equal(nrow(res), 1L)
+})

--- a/tests/testthat/test-kruskal_effsize.R
+++ b/tests/testthat/test-kruskal_effsize.R
@@ -22,8 +22,19 @@ test_that("kruskal_effsize accepts bootstrap parallel options", {
   set.seed(123)
 
   res <- ToothGrowth %>%
-    kruskal_effsize(len ~ dose, ci = TRUE, nboot = 50, parallel = "no", ncpus = 1)
+    kruskal_effsize(len ~ dose, ci = TRUE, nboot = 50,
+                    boot.parallel = "no", boot.ncpus = 1)
 
   expect_true(all(c("conf.low", "conf.high") %in% colnames(res)))
   expect_equal(nrow(res), 1L)
+})
+
+test_that("kruskal_effsize still accepts abbreviated argument names (no regression)", {
+  # The bootstrap arguments are named boot.ncpus (not ncpus) so that `n` keeps
+  # partial-matching unambiguously to `nboot`.
+  skip_if_not_installed("boot")
+  set.seed(123)
+  res <- ToothGrowth %>% kruskal_effsize(len ~ dose, ci = TRUE, n = 200)
+  expect_true(all(c("conf.low", "conf.high") %in% colnames(res)))
+  expect_equal(round(res$effsize, 4), 0.6784)
 })


### PR DESCRIPTION
Previous PR: https://github.com/kassambara/rstatix/pull/87#issuecomment-4848117210

This adds `parallel` and `ncpus` options for bootstrap confidence intervals in the effect size helpers.

Previously, `parallel = "multicore"` was passed to `boot::boot.ci()`, where it has no effect. This change passes the options to `boot::boot()`, where bootstrap resampling happens.

Defaults stay serial (`parallel = "no"`, `ncpus = 1`), so existing behavior should not change unless users opt in.

Also adds small CI-safe tests using `parallel = "no"` and a forwarding check for the bootstrap helper.

