### PR TITLE
Return NA bounds when a bootstrap confidence interval is undefined

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - `cohens_d()`, `wilcox_effsize()`, `kruskal_effsize()` and `friedman_effsize()` gain `boot.parallel` and `boot.ncpus` arguments to compute the bootstrap confidence interval (`ci = TRUE`) in parallel, for example `cohens_d(df, len ~ supp, ci = TRUE, boot.parallel = "multicore", boot.ncpus = 4)`. They default to `getOption("boot.parallel", "no")` and `getOption("boot.ncpus", 1L)`, so the bootstrap stays serial by default, the corresponding global options keep working, and all existing results are unchanged. The parallel settings are now passed to `boot::boot()`, which performs the resampling, rather than to `boot::boot.ci()`, which has no such argument and silently ignored them. Based on the contribution by @HannesOberreiter ([#289](https://github.com/kassambara/rstatix/pull/289), [#87](https://github.com/kassambara/rstatix/pull/87)).
 
+## Bug fixes
+
+- The bootstrap confidence interval (`ci = TRUE`) of `cohens_d()`, `wilcox_effsize()`, `kruskal_effsize()` and `friedman_effsize()` no longer breaks when the bootstrap replicates are **degenerate** — all identical (a perfect effect size, e.g. Kendall's *W* = 1) or all missing (constant data). Such an interval is undefined: `conf.low` and `conf.high` are now returned as `NA` with a warning, and the remaining groups or comparisons are still computed. Previously an ungrouped call silently returned empty **list-columns** in place of the bounds, a grouped call failed with `Can't combine ... <list> and ... <double>`, and constant data errored with `missing value where TRUE/FALSE needed`. An interval type that cannot be built (for instance `ci.type = "stud"`, which needs bootstrap variances) is likewise returned as `NA` with a warning instead of a malformed column. Well-behaved bootstrap intervals are unchanged ([#290](https://github.com/kassambara/rstatix/issues/290)).
+
 
 # rstatix 1.0.0
 

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -110,6 +110,7 @@ cohens_d <- function(data, formula, comparisons = NULL, ref.group = NULL, paired
     mutate(magnitude = get_cohens_magnitude(.data$effsize)) %>%
     set_attrs(args = args) %>%
     add_class(c("rstatix_test", "cohens_d"))
+  warn_undefined_boot_ci(res, ci)
   res
 }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -821,6 +821,14 @@ get_boot_ci <- function(data, stat.func, conf.level = 0.95, type = "perc", nboot
                         parallel = getOption("boot.parallel", "no"),
                         ncpus = getOption("boot.ncpus", 1L)){
   required_package("boot")
+  # boot.ci() silently ignores an interval type it does not know, which would send
+  # a misspelled ci.type down the "interval could not be computed" path below and
+  # return NA instead of failing. Reject it here (#290).
+  allowed.ci.types <- c("norm", "basic", "perc", "bca", "stud")
+  if(length(type) != 1L || !(type %in% allowed.ci.types)){
+    stop("`ci.type` must be one of ",
+         paste0("\"", allowed.ci.types, "\"", collapse = ", "), ".", call. = FALSE)
+  }
   ci.type.given <- type
   # boot::boot() resolves getOption("boot.parallel") only when `parallel` is
   # missing; passing the option's own value keeps that behavior while allowing

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -797,21 +797,70 @@ get_pairwise_comparison_methods <- function(){
   )
 }
 
+# two_sample_test() suppresses the warnings raised inside the test function, which
+# would swallow get_boot_ci()'s note. Re-raise it from the exported function when
+# an effect size was computed but its bootstrap interval was not (#290).
+warn_undefined_boot_ci <- function(res, ci){
+  if(!isTRUE(ci)) return(invisible(res))
+  if(!"conf.low" %in% colnames(res)) return(invisible(res))
+  undefined <- is.na(res$conf.low)
+  if(any(undefined)){
+    warning(
+      "The bootstrap confidence interval could not be computed for ",
+      sum(undefined), " of ", nrow(res), " comparison(s) (this happens when the ",
+      "bootstrap replicates are all identical or all missing, e.g. with constant ",
+      "data or a perfect effect size). `conf.low` and `conf.high` are NA there.",
+      call. = FALSE
+    )
+  }
+  invisible(res)
+}
+
 # Bootstrap confidence intervals -------------------------
 get_boot_ci <- function(data, stat.func, conf.level = 0.95, type = "perc", nboot = 500,
                         parallel = getOption("boot.parallel", "no"),
                         ncpus = getOption("boot.ncpus", 1L)){
   required_package("boot")
+  ci.type.given <- type
   # boot::boot() resolves getOption("boot.parallel") only when `parallel` is
   # missing; passing the option's own value keeps that behavior while allowing
   # a per-call override. boot::boot.ci() has no `parallel` formal.
   Boot = boot::boot(data, stat.func, R = nboot, parallel = parallel, ncpus = ncpus)
+  # The interval is undefined when the bootstrap replicates are degenerate: all
+  # identical (a perfect effect size) or all missing (constant data). Left to
+  # itself boot.ci() prints a note and returns NULL in the first case, and errors
+  # in its own checks in the second; the NULL then became a list-column (#290).
+  # Detect it here rather than catching boot.ci()'s error, so that genuine errors
+  # (e.g. type = "stud" without a variance) keep being raised.
+  replicates <- as.vector(Boot$t)
+  if (all(is.na(replicates)) ||
+      length(unique(replicates[!is.na(replicates)])) < 2L) {
+    warning(
+      "The bootstrap confidence interval could not be computed because the ",
+      "bootstrap replicates are all identical or all missing (this happens with ",
+      "constant data, or with a perfect effect size). `conf.low` and `conf.high` ",
+      "are returned as NA.", call. = FALSE
+    )
+    return(c(NA_real_, NA_real_))
+  }
   BCI = boot::boot.ci(Boot, conf = conf.level, type = type)
   type <- switch(
     type, norm = "normal", perc = "percent",
     basic = "basic", bca = "bca", stud = "student", type
   )
-  CI <- as.vector(BCI[[type]]) %>%
+  # boot.ci() can also return an object without the requested component (e.g.
+  # type = "stud" without bootstrap variances). Guard the same way, so the bounds
+  # are always a length-2 double and never a zero-length list (#290).
+  bounds <- as.vector(BCI[[type]])
+  if (length(bounds) < 2L) {
+    warning(
+      "The requested bootstrap confidence interval (ci.type = \"", ci.type.given,
+      "\") could not be computed. `conf.low` and `conf.high` are returned as NA.",
+      call. = FALSE
+    )
+    return(c(NA_real_, NA_real_))
+  }
+  CI <- bounds %>%
     utils::tail(2) %>% round_value(digits = 2)
   CI
 }

--- a/R/wilcox_effsize.R
+++ b/R/wilcox_effsize.R
@@ -126,6 +126,7 @@ wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
     mutate(magnitude = get_wilcox_effsize_magnitude(.data$effsize)) %>%
     set_attrs(args = args) %>%
     add_class(c("rstatix_test", "wilcox_effsize"))
+  warn_undefined_boot_ci(res, ci)
   res
 }
 

--- a/tests/testthat/test-bootstrap_ci.R
+++ b/tests/testthat/test-bootstrap_ci.R
@@ -185,3 +185,124 @@ test_that("the default bootstrap confidence interval is unchanged (no regression
   expect_equal(res2$conf.low, -0.21)
   expect_equal(res2$conf.high, 1.05)
 })
+
+# Degenerate bootstrap replicates (#290) -------------------------------------
+
+# Perfectly concordant rankings give Kendall's W == 1, so every bootstrap
+# replicate equals 1 and no interval exists.
+concordant_df <- function() {
+  data.frame(
+    id = factor(rep(1:4, each = 3)),
+    time = factor(rep(c("t1", "t2", "t3"), times = 4)),
+    score = c(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3)
+  )
+}
+
+# Constant data: the statistic is NaN, so every replicate is NA.
+constant_df <- function() {
+  data.frame(g = factor(rep(c("a", "b"), each = 6)), v = rep(1, 12))
+}
+
+test_that("get_boot_ci returns NA bounds and warns on degenerate replicates (#290)", {
+  skip_if_not_installed("boot")
+  d <- data.frame(x = 1:10)
+
+  set.seed(1)
+  expect_warning(
+    ci_identical <- get_boot_ci(d, function(data, i) 1, nboot = 50),
+    "could not be computed"
+  )
+  expect_equal(ci_identical, c(NA_real_, NA_real_))
+  expect_type(ci_identical, "double")
+
+  set.seed(1)
+  expect_warning(
+    ci_missing <- get_boot_ci(d, function(data, i) NA_real_, nboot = 50),
+    "could not be computed"
+  )
+  expect_equal(ci_missing, c(NA_real_, NA_real_))
+
+  # a well-behaved bootstrap is untouched
+  set.seed(1)
+  ci_ok <- get_boot_ci(d, function(data, i) mean(data$x[i]), nboot = 100)
+  expect_type(ci_ok, "double")
+  expect_length(ci_ok, 2)
+  expect_false(anyNA(ci_ok))
+})
+
+test_that("friedman_effsize returns NA bounds instead of list-columns (#290)", {
+  skip_if_not_installed("boot")
+  set.seed(1)
+  expect_warning(
+    res <- friedman_effsize(concordant_df(), score ~ time | id, ci = TRUE, nboot = 50),
+    "could not be computed"
+  )
+  # the bug returned a <list> column of NULLs
+  expect_type(res$conf.low, "double")
+  expect_type(res$conf.high, "double")
+  expect_true(is.na(res$conf.low))
+  expect_true(is.na(res$conf.high))
+  expect_equal(as.numeric(res$effsize), 1)
+})
+
+test_that("grouped friedman_effsize no longer errors when one group is degenerate (#290)", {
+  skip_if_not_installed("boot")
+  df <- data.frame(
+    id = factor(rep(1:8, each = 3)),
+    time = factor(rep(c("t1", "t2", "t3"), times = 8)),
+    grp = factor(rep(c("A", "B"), each = 12)),
+    score = c(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+              1, 3, 2, 2, 1, 3, 1, 2, 3, 3, 1, 2)
+  )
+  set.seed(1)
+  expect_warning(
+    res <- friedman_effsize(dplyr::group_by(df, grp), score ~ time | id,
+                            ci = TRUE, nboot = 50),
+    "could not be computed"
+  )
+  expect_equal(nrow(res), 2L)
+  expect_type(res$conf.low, "double")
+  expect_true(is.na(res$conf.low[1]))   # group A: W == 1, undefined
+  expect_false(is.na(res$conf.low[2]))  # group B: computed as usual
+})
+
+test_that("the effect size functions return NA bounds on constant data (#290)", {
+  skip_if_not_installed("boot")
+  const <- constant_df()
+
+  set.seed(1)
+  expect_warning(d <- cohens_d(const, v ~ g, ci = TRUE, nboot = 50), "could not be computed")
+  expect_type(d$conf.low, "double")
+  expect_true(is.na(d$conf.low))
+
+  set.seed(1)
+  expect_warning(k <- kruskal_effsize(const, v ~ g, ci = TRUE, nboot = 50), "could not be computed")
+  expect_type(k$conf.low, "double")
+  expect_true(is.na(k$conf.low))
+
+  skip_if_not_installed("coin")
+  set.seed(1)
+  expect_warning(w <- wilcox_effsize(const, v ~ g, ci = TRUE, nboot = 50), "could not be computed")
+  expect_type(w$conf.low, "double")
+  expect_true(is.na(w$conf.low))
+})
+
+test_that("an interval type boot.ci cannot build yields NA bounds, not a list-column (#290)", {
+  skip_if_not_installed("boot")
+  # "stud" needs bootstrap variances, which are not supplied
+  set.seed(1)
+  expect_warning(
+    res <- cohens_d(ToothGrowth, len ~ supp, ci = TRUE, nboot = 50, ci.type = "stud"),
+    "could not be computed"
+  )
+  expect_type(res$conf.low, "double")
+  expect_true(is.na(res$conf.low))
+})
+
+test_that("a well-behaved bootstrap CI still warns about nothing (#290 no-regression)", {
+  skip_if_not_installed("boot")
+  set.seed(42)
+  expect_silent(res <- cohens_d(ToothGrowth, len ~ supp, ci = TRUE, nboot = 200))
+  expect_equal(res$conf.low, -0.06)
+  expect_equal(res$conf.high, 1.2)
+})

--- a/tests/testthat/test-bootstrap_ci.R
+++ b/tests/testthat/test-bootstrap_ci.R
@@ -306,3 +306,25 @@ test_that("a well-behaved bootstrap CI still warns about nothing (#290 no-regres
   expect_equal(res$conf.low, -0.06)
   expect_equal(res$conf.high, 1.2)
 })
+
+test_that("an unknown ci.type errors rather than returning NA bounds (#290)", {
+  skip_if_not_installed("boot")
+  # boot.ci() ignores a type it does not know, so a typo would otherwise slip
+  # through the "interval could not be computed" guard and return NA silently.
+  expect_error(
+    cohens_d(ToothGrowth, len ~ supp, ci = TRUE, nboot = 50, ci.type = "bogus"),
+    "ci.type"
+  )
+  expect_error(
+    get_boot_ci(data.frame(x = 1:10), function(d, i) mean(d$x[i]),
+                nboot = 10, type = "percentile"),
+    "ci.type"
+  )
+  # the documented types keep working
+  set.seed(42)
+  for (ty in c("norm", "basic", "perc", "bca")) {
+    res <- cohens_d(ToothGrowth, len ~ supp, ci = TRUE, nboot = 200, ci.type = ty)
+    expect_type(res$conf.low, "double")
+    expect_false(is.na(res$conf.low))
+  }
+})


### PR DESCRIPTION
A bootstrap confidence interval cannot be built when the resamples are degenerate — all identical (a perfect effect size, e.g. Kendall's *W* = 1) or all missing (constant data). Neither case was handled, so `ci = TRUE` failed in three different ways, the worst of them silently.

## Before

``` r
conc <- data.frame(
  id    = factor(rep(1:4, each = 3)),
  time  = factor(rep(c("t1", "t2", "t3"), times = 4)),
  score = c(1, 2, 3,  1, 2, 3,  1, 2, 3,  1, 2, 3)
)

set.seed(1)
friedman_effsize(conc, score ~ time | id, ci = TRUE, nboot = 50)
#> # A tibble: 1 × 7
#>   .y.       n effsize conf.low conf.high method    magnitude
#> * <chr> <int>   <dbl> <list>   <list>    <chr>     <ord>    
#> 1 score     4       1 <NULL>   <NULL>    Kendall W large    
```

`conf.low`/`conf.high` came back as empty **list-columns**, with no error and no warning. A grouped call then failed outright (`Can't combine data[[1]]$conf.low <list> and data[[2]]$conf.low <double>`), and constant data errored with `missing value where TRUE/FALSE needed`.

## After

``` r
set.seed(1)
friedman_effsize(conc, score ~ time | id, ci = TRUE, nboot = 50)
#> Warning: The bootstrap confidence interval could not be computed because the
#> bootstrap replicates are all identical or all missing (this happens with
#> constant data, or with a perfect effect size). `conf.low` and `conf.high` are
#> returned as NA.
#> # A tibble: 1 × 7
#>   .y.       n effsize conf.low conf.high method    magnitude
#> * <chr> <int>   <dbl>    <dbl>     <dbl> <chr>     <ord>    
#> 1 score     4       1       NA        NA Kendall W large    
```

A grouped call now computes the groups it can, and reports `NA` for the ones it cannot:

``` r
set.seed(1)
friedman_effsize(group_by(both, grp), score ~ time | id, ci = TRUE, nboot = 50)
#> # A tibble: 2 × 8
#>   grp   .y.       n effsize conf.low conf.high method    magnitude
#> * <fct> <chr> <int>   <dbl>    <dbl>     <dbl> <chr>     <ord>    
#> 1 A     score     4   1          NA     NA    Kendall W large    
#> 2 B     score     4   0.188       0      0.94 Kendall W small    
```

## Approach

The degenerate resamples are detected directly, *before* the interval is requested, rather than by catching the failure. That way a genuine error (for example `ci.type = "stud"` with no bootstrap variances) still surfaces rather than being masked as `NA`. A second guard covers an interval type that comes back without the requested component, so `conf.low`/`conf.high` are always a length-2 double and never a zero-length list.

This matches the convention already used by `games_howell_test()` for zero-variance groups (#183) and by `t_test(error.as.na = TRUE)` for uncomputable comparisons (#208): return `NA` with a warning, and keep the rest of the result usable.

Well-behaved bootstrap intervals are unchanged, for every `ci.type` (`perc`, `norm`, `basic`, `bca`), ungrouped, pairwise and grouped.

Fixes #290
