### PR TITLE
R CMD check fails without Suggests: guard the examples and tests that need emmeans/coin

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,7 +12,7 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }}${{ matrix.config.label && format(', {0}', matrix.config.label) || '' }})
 
     strategy:
       fail-fast: false
@@ -23,10 +23,16 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          # CRAN checks one flavour with only Depends/Imports/LinkingTo installed.
+          # dunnett_test(), emmeans_test() and wilcox_effsize() stop() without their
+          # Suggests package, so an unguarded example or test errors there and
+          # nowhere else. Without this entry that failure is invisible to us.
+          - {os: ubuntu-latest,   r: 'release', label: 'noSuggests', deps: 'hard', depends-only: 'true'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.depends-only || 'false' }}
 
     steps:
       - uses: actions/checkout@v3
@@ -42,6 +48,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
+          dependencies: ${{ matrix.config.deps && '"hard"' || '"all"' }}
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 ## Bug fixes
 
+- `R CMD check` no longer fails when the packages in `Suggests` are absent, the configuration CRAN checks with `_R_CHECK_DEPENDS_ONLY_=true`. `dunnett_test()` and `emmeans_test()` stop without `emmeans`, and `wilcox_effsize()` stops without `coin`; their examples now run only when the package is installed, and the two test blocks that reached them without a guard now skip. The examples of `dunnett_test()` and `emmeans_test()` are wrapped in `requireNamespace()` rather than `\donttest{}`, which does not help: `R CMD check --as-cran` runs those blocks as well. A `noSuggests` job is added to the check matrix so the configuration is exercised ([#296](https://github.com/kassambara/rstatix/issues/296)).
+
 - The bootstrap confidence interval (`ci = TRUE`) of `cohens_d()`, `wilcox_effsize()`, `kruskal_effsize()` and `friedman_effsize()` no longer breaks when the bootstrap replicates are **degenerate** — all identical (a perfect effect size, e.g. Kendall's *W* = 1) or all missing (constant data). Such an interval is undefined: `conf.low` and `conf.high` are now returned as `NA` with a warning, and the remaining groups or comparisons are still computed. Previously an ungrouped call silently returned empty **list-columns** in place of the bounds, a grouped call failed with `Can't combine ... <list> and ... <double>`, and constant data errored with `missing value where TRUE/FALSE needed`. An interval type that cannot be built (for instance `ci.type = "stud"`, which needs bootstrap variances) is likewise returned as `NA` with a warning instead of a malformed column. Well-behaved bootstrap intervals are unchanged ([#290](https://github.com/kassambara/rstatix/issues/290)).
 
 

--- a/R/dunnett_test.R
+++ b/R/dunnett_test.R
@@ -44,6 +44,8 @@ NULL
 #'@seealso \code{\link{tukey_hsd}()}, \code{\link{games_howell_test}()},
 #'  \code{\link{emmeans_test}()}
 #' @examples
+#' if (requireNamespace("emmeans", quietly = TRUE)) {
+#'
 #' # Compare each dose to the control dose ("0.5")
 #' ToothGrowth %>% dunnett_test(len ~ dose)
 #'
@@ -54,6 +56,8 @@ NULL
 #' ToothGrowth %>%
 #'   group_by(supp) %>%
 #'   dunnett_test(len ~ dose)
+#'
+#' }
 #'@export
 dunnett_test <- function(data, formula, ref.group = NULL, conf.level = 0.95,
                          detailed = FALSE){

--- a/R/emmeans_test.R
+++ b/R/emmeans_test.R
@@ -36,6 +36,8 @@ NULL
 #'  holding the test arguments. It has also an attribute named "emmeans", a data
 #'  frame containing the groups emmeans.
 #'@examples
+#' if (requireNamespace("emmeans", quietly = TRUE)) {
+#'
 #' # Data preparation
 #' df <- ToothGrowth
 #' df$dose <- as.factor(df$dose)
@@ -72,6 +74,8 @@ NULL
 #' )
 #' rm_model <- stats::aov(score ~ time + Error(id / time), data = d)
 #' d %>% emmeans_test(score ~ time, model = rm_model)
+#' }
+#'
 #' }
 #'@export
 emmeans_test <- function(data, formula, covariate = NULL, ref.group = NULL,

--- a/man/dunnett_test.Rd
+++ b/man/dunnett_test.Rd
@@ -64,6 +64,8 @@ Performs Dunnett's test for comparing each of several treatment
  "Dunnett"))}.
 }
 \examples{
+if (requireNamespace("emmeans", quietly = TRUE)) {
+
 # Compare each dose to the control dose ("0.5")
 ToothGrowth \%>\% dunnett_test(len ~ dose)
 
@@ -74,6 +76,8 @@ ToothGrowth \%>\% dunnett_test(len ~ dose, detailed = TRUE)
 ToothGrowth \%>\%
   group_by(supp) \%>\%
   dunnett_test(len ~ dose)
+
+}
 }
 \references{
 Dunnett, C. W. (1955) A multiple comparison procedure for comparing

--- a/man/emmeans_test.Rd
+++ b/man/emmeans_test.Rd
@@ -94,6 +94,8 @@ Performs pairwise comparisons between groups using the estimated
 
 }}
 \examples{
+if (requireNamespace("emmeans", quietly = TRUE)) {
+
 # Data preparation
 df <- ToothGrowth
 df$dose <- as.factor(df$dose)
@@ -130,5 +132,7 @@ d <- data.frame(
 )
 rm_model <- stats::aov(score ~ time + Error(id / time), data = d)
 d \%>\% emmeans_test(score ~ time, model = rm_model)
+}
+
 }
 }

--- a/tests/testthat/test-emmeans_test.R
+++ b/tests/testthat/test-emmeans_test.R
@@ -1,5 +1,6 @@
 
 test_that("emmeans_test works", {
+  skip_if_not_installed("emmeans")
   # Data preparation
   df <- ToothGrowth
   df$dose <- as.factor(df$dose)

--- a/tests/testthat/test-tidyselect-deprecations.R
+++ b/tests/testthat/test-tidyselect-deprecations.R
@@ -28,6 +28,8 @@ tidyselect_deprecations <- function(expr) {
 }
 
 test_that("core test functions emit no tidyselect deprecation (#202)", {
+  # wilcox_effsize() below reaches coin, which stops when it is not installed.
+  skip_if_not_installed("coin")
   df <- ToothGrowth
   df$dose <- factor(df$dose)
   deps <- tidyselect_deprecations({


### PR DESCRIPTION
CRAN checks one configuration with `_R_CHECK_DEPENDS_ONLY_=true`, which installs only `Depends`,
`Imports` and `LinkingTo`. Three exported functions stop when their `Suggests` package is missing:

| function | needs | line |
|---|---|---|
| `dunnett_test()` | `emmeans` | `R/dunnett_test.R:80` |
| `emmeans_test()` | `emmeans` | `R/emmeans_test.R:86` |
| `wilcox_effsize()` | `coin` | `R/wilcox_effsize.R:140` |

That is the intended behaviour of `required_package()`. The examples and two test blocks called those
functions without a guard, so the configuration ended in three ERRORs.

```
_R_CHECK_DEPENDS_ONLY_=true R CMD check rstatix_1.0.0.999.tar.gz --as-cran --no-manual
#> * checking examples ... ERROR
#> * checking examples with --run-donttest ... ERROR
#> * checking tests ... ERROR
#> Status: 3 ERRORs, 2 NOTEs
```

After this change:

```
#> * checking examples ... OK
#> * checking examples with --run-donttest ... OK
#> * checking tests ... OK
#> Status: 1 NOTE
```

## `\donttest{}` is not a guard

`emmeans_test()`'s example was already wrapped in `\donttest{}`, and it still failed. `R CMD check
--as-cran` runs those blocks a second time under `checking examples with --run-donttest`, so the
wrapper delays the error rather than preventing it. Both examples now use `requireNamespace()`, which
is what `wilcox_effsize()`'s example already did.

## What changed

- The examples of `dunnett_test()` and `emmeans_test()` run only when `emmeans` is installed.
- The first block of `test-emmeans_test.R` and the block of `test-tidyselect-deprecations.R` that
  reaches `coin` through `wilcox_effsize()` now skip when the package is absent. The other blocks in
  those files already guarded.
- The check matrix gains a `noSuggests` job: `dependencies: "hard"` and `_R_CHECK_DEPENDS_ONLY_=true`.

## Why the existing jobs never saw it

All five install `Suggests`, so the tests pass on every platform whether or not a call is guarded. A
missing guard is invisible to them.

## Non-regression

No exported function changes; every pre-existing call returns an identical result. With `Suggests`
installed the suite reports 905 tests passing with zero skips, unchanged, and `R CMD check --as-cran`
reports no `WARNING` or `ERROR`. Without them the suite skips 20 tests and fails none. The five
existing matrix entries set `_R_CHECK_DEPENDS_ONLY_=false`, which R reads as false, so they behave
exactly as before.

Fixes #296

