### PR TITLE
Add a Get started vignette

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,7 +27,14 @@ jobs:
           # dunnett_test(), emmeans_test() and wilcox_effsize() stop() without their
           # Suggests package, so an unguarded example or test errors there and
           # nowhere else. Without this entry that failure is invisible to us.
-          - {os: ubuntu-latest,   r: 'release', label: 'noSuggests', deps: 'hard', depends-only: 'true'}
+          # Skip vignette tests here (--ignore-vignettes): the vignette engine
+          # (rmarkdown) is a Suggests package and is hidden under
+          # _R_CHECK_DEPENDS_ONLY_, so re-building the vignette would fail on the
+          # engine, not on package code. CRAN's own depends-only flavour makes
+          # the engine available and passes the same setup the sibling packages
+          # use. This job's purpose -- catching unguarded Suggests use in
+          # examples/tests -- is unaffected; those still run.
+          - {os: ubuntu-latest,   r: 'release', label: 'noSuggests', deps: 'hard', depends-only: 'true', check-args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -53,4 +60,5 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
+          args: ${{ matrix.config.check-args || 'c("--no-manual", "--as-cran")' }}
           upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Suggests:
     boot,
     testthat (>= 3.1.7),
     spelling
+VignetteBuilder: knitr
 URL: https://rpkgs.datanovia.com/rstatix/
 BugReports: https://github.com/kassambara/rstatix/issues
 Collate:

--- a/vignettes/rstatix.Rmd
+++ b/vignettes/rstatix.Rmd
@@ -1,0 +1,167 @@
+---
+title: "Get started with rstatix"
+author: "Alboukadel Kassambara"
+output:
+  rmarkdown::html_vignette:
+    toc: true
+    toc_depth: 2
+vignette: >
+  %\VignetteIndexEntry{Get started with rstatix}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  message = FALSE,
+  warning = FALSE
+)
+options(digits = 3)
+```
+
+`rstatix` provides a simple, pipe-friendly framework for common statistical
+tests, coherent with the `tidyverse` design philosophy. Each function takes a
+data frame and a formula, and returns the result as a **tidy tibble** — so a
+test flows straight into `dplyr` pipelines, into reporting tables
+(`gtsummary`, `gt`, `broom`), and into `ggpubr` plots, without reshaping.
+
+This vignette walks one analysis from start to finish: describe the data, check
+the assumptions, run the test, quantify the effect with a confidence interval,
+and report it. The same handful of verbs covers t-tests, Wilcoxon tests, ANOVA,
+Kruskal-Wallis, correlation, and their effect sizes.
+
+```{r}
+library(rstatix)
+library(dplyr)
+```
+
+We use `ToothGrowth`, a base R dataset: the length of odontoblasts (`len`) in 60
+guinea pigs, each given one of three vitamin C doses (`dose`) by one of two
+delivery methods (`supp`).
+
+```{r}
+df <- ToothGrowth
+df$dose <- factor(df$dose)
+head(df)
+```
+
+## Describe the data
+
+`get_summary_stats()` returns the summaries you actually report, for one or many
+variables, grouped or not.
+
+```{r}
+df %>%
+  group_by(dose) %>%
+  get_summary_stats(len, type = "mean_sd")
+```
+
+## Check the assumptions
+
+Before comparing the three doses, `check_test_assumptions()` tests normality
+(Shapiro-Wilk, per group) and homogeneity of variance (Levene), and returns a
+one-row recommendation: which omnibus test and which post-hoc test the data
+call for.
+
+```{r}
+df %>% check_test_assumptions(len ~ dose)
+```
+
+Here both assumptions hold, so the recommendation is a one-way ANOVA followed by
+Tukey HSD. When normality fails it points to Kruskal-Wallis with Dunn's test;
+when only the variances differ, to Welch ANOVA with Games-Howell. (Choosing a
+test by first testing its assumptions on the same data is a known trade-off,
+noted in `?check_test_assumptions` — pre-specifying the test is always
+defensible.)
+
+## Run the omnibus test
+
+Follow the recommendation. `anova_test()` returns the ANOVA table; asking for
+the partial eta-squared effect size with a confidence interval adds `pes` and
+its bounds.
+
+```{r}
+df %>% anova_test(len ~ dose, effect.size = "pes", ci = 0.95)
+```
+
+Dose has a large, highly significant effect on tooth length.
+
+## Post-hoc comparisons
+
+`posthoc_test()` runs the post-hoc appropriate to the same decision tree and
+shows which test it picked and why, so the routing is transparent.
+
+```{r}
+df %>% posthoc_test(len ~ dose)
+```
+
+Every pairwise difference is significant after adjustment. If you prefer to
+drive the pairwise step yourself, the individual verbs compose the same way —
+`tukey_hsd()`, or `dunn_test()` / `games_howell_test()` — and any pairwise test
+can be piped through `adjust_pvalue()` and `add_significance()`.
+
+## Quantify the effect
+
+A p-value tells you an effect exists; an effect size tells you how large. For a
+pairwise mean comparison that is Cohen's d:
+
+```{r}
+df %>% cohens_d(len ~ dose)
+```
+
+Each metric has a matching verb, all with the same interface and an optional
+confidence interval via `ci = TRUE`: `eta_squared()` for ANOVA, `cramer_v()` for
+association, `cliff_delta()` and `wilcox_effsize()` for the non-parametric case,
+`kruskal_effsize()` for Kruskal-Wallis.
+
+## Report it
+
+For a manuscript, `get_test_label(style = "apa")` writes the APA-7 in-text
+sentence, including the effect-size confidence interval when the result carries
+one:
+
+```{r}
+model <- df %>% anova_test(len ~ dose, effect.size = "pes", ci = 0.95)
+get_test_label(model, type = "text", style = "apa")
+```
+
+Because every result is a tibble, `tidy()` and `glance()` hand it to the
+reporting-table ecosystem (`broom`, `gtsummary`, `gt`):
+
+```{r}
+df %>% anova_test(len ~ dose) %>% tidy()
+df %>% anova_test(len ~ dose) %>% glance()
+```
+
+## Grouped analysis in one call
+
+The workflow is `group_by()`-aware: run the same test within every level of a
+grouping variable, then adjust and flag, in a single pipe. Here we compare the
+two delivery methods within each dose.
+
+```{r}
+df %>%
+  group_by(dose) %>%
+  t_test(len ~ supp) %>%
+  adjust_pvalue(method = "holm") %>%
+  add_significance()
+```
+
+The delivery method matters at the two lower doses but not at the highest.
+
+## Plotting and further reading
+
+`rstatix` returns the data; `ggpubr` draws it. The tidy result of any test pipes
+straight into a plot: `add_xy_position()` places the significance brackets and
+`stat_pvalue_manual()` adds them, so the p-values on the figure are the ones you
+computed. See the [ggpubr](https://rpkgs.datanovia.com/ggpubr/) documentation.
+
+Extended tutorials — comparing means, ANOVA designs, correlation analysis,
+effect sizes — are on the package website:
+<https://rpkgs.datanovia.com/rstatix/>.
+
+```{r}
+sessionInfo()
+```


### PR DESCRIPTION
Adds a single introductory vignette, `vignettes/rstatix.Rmd` ("Get started with rstatix").

## What it does

Walks one analysis end to end on a base R dataset (`ToothGrowth`), following the tidy workflow:
summary statistics → assumption check (`check_test_assumptions()`) → the omnibus test the check
recommends (`anova_test()` with a partial eta-squared confidence interval) → post-hoc
(`posthoc_test()`, showing which test it routed to and why) → effect size (`cohens_d()`) → the APA-7
sentence (`get_test_label(style = "apa")`) → `tidy()`/`glance()` for reporting tables → a grouped
one-pipe analysis. It closes with a pointer to ggpubr for plotting and to the website for the deeper
tutorials.

## Why one, and dependency-clean

rstatix has shipped no in-package vignette (tutorials live on the website). This adds the single
highest-leverage on-ramp — the one a user meets on the CRAN page and via `vignette("rstatix")`, offline
— without mirroring the website's tutorial set. It uses only `rstatix` and `dplyr` (an Import), no
Suggests package, so it builds cleanly under `_R_CHECK_DEPENDS_ONLY_=true` and adds no new dependency:
`knitr` and `rmarkdown` were already in Suggests, so only `VignetteBuilder: knitr` is added.

## Checks

- `R CMD check --as-cran`: Status OK (0/0/0). The `_R_CHECK_DEPENDS_ONLY_` flavour: Status OK.
- Every printed table and the APA sentence were run and confirmed before writing the prose; the
  narrative claims (assumptions hold → ANOVA + Tukey; large significant dose effect; all pairwise
  differences significant; delivery method matters at the two lower doses but not the highest) match
  the computed output.
- No R code changed — only the new vignette and the `VignetteBuilder` field.

## Decisions to take
- Whether a single introductory vignette in the package is wanted, given tutorials live on the website.
- Which release to fold it into (it is independent of the pending 1.1.0 submission).
