### PR TITLE
Add two missing exports to the pkgdown reference

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
+url: https://rpkgs.datanovia.com/rstatix
 templates:
   params:
     bootswatch: lumen
@@ -92,6 +93,7 @@ reference:
   - title: Extract Information From Statistical Tests
     contents:
       - get_test_label
+      - get_pwc_label
       - remove_ns
       - tidy.rstatix_test
   - title: Data Manipulation Helper Functions
@@ -104,6 +106,7 @@ reference:
       - df_split_by
       - df_unite
       - df_label_value
+      - df_label_both
       - df_get_var_names
   - title: Others
     contents:


### PR DESCRIPTION
`get_pwc_label()` and `df_label_both()` have been exported since 1.0.0 but were never listed in `_pkgdown.yml`, so neither had a page in the reference index. This adds them next to their siblings (`get_test_label`, `df_label_value`) and sets the site `url`. `pkgdown::check_pkgdown()` reports no problems.

No code change; `_pkgdown.yml` only. The rendered site itself is best rebuilt at release time (alongside the README re-render and the vignette), not now while 1.1.0 is held.