### PR TITLE
Install the test driver explicitly in the noSuggests check job

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,7 +38,13 @@ jobs:
           # tarball, so it never hits this. This job's purpose -- catching
           # unguarded Suggests use in examples/tests -- is unaffected; those
           # still run.
-          - {os: ubuntu-latest,   r: 'release', label: 'noSuggests', deps: 'hard', depends-only: 'true', check-args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")', build-args: 'c("--no-manual", "--no-build-vignettes")'}
+          # extra-packages adds the test driver: tests/testthat.R needs
+          # library(testthat) to run at all, and CRAN's depends-only flavour has
+          # the driver available too -- only the package's own code is limited
+          # to hard dependencies. (pak's resolver used to install it implicitly
+          # under deps: hard, like the vignette engine above; it stopped in
+          # July 2026 and the check step started dying at library(testthat).)
+          - {os: ubuntu-latest,   r: 'release', label: 'noSuggests', deps: 'hard', depends-only: 'true', check-args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")', build-args: 'c("--no-manual", "--no-build-vignettes")', extra-packages: 'any::rcmdcheck, any::testthat'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -58,7 +64,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: ${{ matrix.config.extra-packages || 'any::rcmdcheck' }}
           dependencies: ${{ matrix.config.deps && '"hard"' || '"all"' }}
           needs: check
 


### PR DESCRIPTION
The pak resolver change that stopped installing the vignette engine under `deps: hard` (fixed in #314 with `--no-build-vignettes`) also stopped installing testthat, so the noSuggests job now dies at `library(testthat)` before any test runs — see the #308 re-run at 8befbac. The earlier green run at 9783f39 happened to get testthat from the resolver/cache; that is not deterministic.

This installs the test driver explicitly for that job only. CRAN's depends-only flavour likewise has the driver available while the package's own code sees only hard dependencies, and the `skip_if_not_installed()` guards keep exercising the Suggests-absent paths (the job's purpose).

Refs #308