### PR TITLE
Link help pages and the README to the corresponding Datanovia tutorials

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@
 
 ## Minor changes
 
+- Function help pages and the README now link to the corresponding Datanovia tutorials.
+
 - New documentation topic `?rstatix-references` collecting the sources of the methods `rstatix` implements — Cramer (1946), Smithson (2003), Steiger (2004), Conover (1999), Nemenyi (1963), Piepho (2004), Dunnett (1955) — and naming the packages that implement some of the same methods and offer functionality `rstatix` does not: `effectsize`, `DescTools`, `multcomp`, `multcompView` and `PMCMRplus`. Every function that documents such an agreement now names the function it agrees with, and the arguments needed to reproduce it: `conover_test()`, `friedman_conover_test()` and `friedman_nemenyi_test()` record the corresponding `PMCMRplus` function, and `anova_test(ci = )` records `effectsize::eta_squared(partial = TRUE, ci = , alternative = "two.sided")`. The agreements of `dunnett_test()` with `DescTools::DunnettTest()` and `multcomp::glht()`, and of `sign_test()` with `DescTools::SignTest()`, which the documentation already claimed, are now checked by the test suite.
 
 - The note on `sign_test()` now records that its test code and its confidence interval for the median are adapted from `DescTools::SignTest()` and `DescTools::MedianCI()`, written by Andri Signorell, rather than only naming the package. `?rstatix-references` records the same, and separates the functions whose code is adapted from another package from the several that call one.

--- a/R/anova_summary.R
+++ b/R/anova_summary.R
@@ -9,6 +9,10 @@ NULL
 #'  The results include ANOVA table, generalized effect size and some assumption
 #'  checks.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+#'  for a worked walkthrough.
+#'
 #'@param effect.size the effect size to compute and to show in the ANOVA
 #'  results. Allowed values can be either "ges" (generalized eta squared) or
 #'  "pes" (partial eta squared) or both. Default is "ges".
@@ -63,6 +67,7 @@ NULL
 #'
 #'@author Alboukadel Kassambara, \email{alboukadel.kassambara@@gmail.com}
 #'@seealso \code{\link{anova_test}()}, \code{\link{factorial_design}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 #' @examples
 #'# Load data
 #'#:::::::::::::::::::::::::::::::::::::::

--- a/R/anova_test.R
+++ b/R/anova_test.R
@@ -97,6 +97,7 @@ NULL
 #'  factors violating the sphericity assumption (i.e., Mauchly's test p-value is
 #'  significant, p <= 0.05). }
 #'@seealso \code{\link{anova_summary}()}, \code{\link{factorial_design}()}
+#'   The Datanovia tutorials: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}, \href{https://www.datanovia.com/learn/biostatistics/anova/repeated-measures-anova-in-r}{Repeated Measures ANOVA in R}, \href{https://www.datanovia.com/learn/biostatistics/anova/mixed-anova-in-r}{Mixed ANOVA in R}, \href{https://www.datanovia.com/learn/biostatistics/anova/ancova-in-r}{ANCOVA in R}.
 #'@return return an object of class \code{anova_test} a data frame containing
 #'  the ANOVA table for independent measures ANOVA.
 #'

--- a/R/as_cor_mat.R
+++ b/R/as_cor_mat.R
@@ -5,11 +5,16 @@ NULL
 #' @description Convert a correlation test data frame, returned by the
 #'   \code{\link{cor_test}()}, into a correlation matrix format.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+#'  for a worked walkthrough.
+#'
 #' @param x an object of class \code{cor_test}.
 #' @return  Returns a data frame containing the matrix of the correlation
 #'   coefficients. The output has an attribute named "pvalue", which contains
 #'   the matrix of the correlation test p-values.
 #' @seealso \code{\link{cor_mat}()}, \code{\link{cor_test}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 #' @examples
 #' # Pairwise correlation tests between variables
 #' #:::::::::::::::::::::::::::::::::::::::::::::::

--- a/R/box_m.R
+++ b/R/box_m.R
@@ -6,6 +6,10 @@ NULL
 #' @description Performs the Box's M-test for homogeneity of covariance matrices
 #'   obtained from multivariate normal data according to one grouping variable.
 #'   The test is based on the chi-square approximation.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}
+#'  for a worked walkthrough.
 #' @param data a numeric data.frame or matrix containing n observations of p
 #'   variables; it is expected that n > p.
 #' @param group a vector of length n containing the class of each
@@ -18,6 +22,7 @@ NULL
 #' @examples
 #' data(iris)
 #' box_m(iris[, -5], iris[, 5])
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}.
 #' @export
 box_m <-function(data, group)
   {

--- a/R/check_test_assumptions.R
+++ b/R/check_test_assumptions.R
@@ -30,6 +30,10 @@ NULL
 #'   or a rank-based test. Treat this recommendation as guidance, not a
 #'   substitute for judgement.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions}{Statistical Tests and Assumptions in R}
+#'  for a worked walkthrough.
+#'
 #' @param data a data frame containing the variables in the formula.
 #' @param formula a formula of the form \code{x ~ group} where \code{x} is a
 #'   numeric outcome and \code{group} is a factor with two or more levels.
@@ -44,6 +48,7 @@ NULL
 #'
 #' @seealso \code{\link{posthoc_test}()}, \code{\link{shapiro_test}()},
 #'   \code{\link{levene_test}()}.
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions}{Statistical Tests and Assumptions in R}.
 #'
 #' @examples
 #' df <- ToothGrowth

--- a/R/chisq_test.R
+++ b/R/chisq_test.R
@@ -12,6 +12,10 @@ NULL
 #'  table is built internally. Note that in the positional form the second column
 #'  occupies the \code{correct} argument slot, so use the \code{vars} form (or the
 #'  table interface) if you need to set \code{correct}/\code{simulate.p.value}.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r}{Chi-Square Test of Independence in R}
+#'  for a worked walkthrough.
 #'@inheritParams  stats::chisq.test
 #'@param vars optional character vector of length two giving the names of two
 #'  columns in the data frame \code{x} to cross-tabulate for a test of
@@ -76,6 +80,7 @@ NULL
 #' df %>% chisq_test(gender, smoker)
 #' # Equivalent, using vars (keeps `correct` settable)
 #' df %>% chisq_test(vars = c("gender", "smoker"), correct = FALSE)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r}{Chi-Square Test of Independence in R}, \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-goodness-of-fit-test-in-r}{Chi-Square Goodness-of-Fit Test in R}.
 
 
 #' @describeIn chisq_test performs chi-square tests including goodness-of-fit,

--- a/R/cliff_delta.R
+++ b/R/cliff_delta.R
@@ -11,6 +11,10 @@ NULL
 #'   \code{-1} to \code{1} and, unlike the rank-biserial \code{r}, is unaffected
 #'   by ties beyond their contribution to the counts.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}
+#'  for a worked walkthrough.
+#'
 #' @inheritParams wilcox_effsize
 #' @param ... other arguments; accepted for interface compatibility with
 #'   \code{\link{cohens_d}()} and \code{\link{wilcox_effsize}()} but not used
@@ -53,6 +57,7 @@ NULL
 #' ToothGrowth %>%
 #'   dplyr::group_by(supp) %>%
 #'   cliff_delta(len ~ dose)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}.
 #' @export
 cliff_delta <- function(data, formula, comparisons = NULL, ref.group = NULL,
                         ci = FALSE, conf.level = 0.95, ci.type = "perc",

--- a/R/cochran_qtest.R
+++ b/R/cochran_qtest.R
@@ -6,6 +6,10 @@ NULL
 #'  test is analogue to the \code{\link{friedman.test}()} with 0,1 coded
 #'  response. It's an extension of the McNemar Chi-squared test for comparing
 #'  more than two paired proportions.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/categorical/cochran-q-test-in-r}{Cochran’s Q Test in R}
+#'  for a worked walkthrough.
 #'@param data a data frame containing the variables in the formula.
 #'@param formula a formula of the form \code{a ~ b | c}, where \code{a} is the
 #'  outcome variable name; b is the within-subjects factor variables; and c
@@ -31,6 +35,7 @@ NULL
 #' # pairwise comparisons between groups
 #' pairwise_mcnemar_test(mydata, outcome ~ treatment|participant)
 #'
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/cochran-q-test-in-r}{Cochran’s Q Test in R}.
 #'@export
 cochran_qtest <- function(data, formula){
   args <- as.list(environment()) %>%

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -24,6 +24,10 @@ NULL
 #'  bootstrap (the default) or by an analytic, deterministic method (see
 #'  \code{ci.method}).
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/cohens-d-effect-size}{Cohen’s d Effect Size in R}
+#'  for a worked walkthrough.
+#'
 #'@inheritParams wilcox_effsize
 #'@param ci.method the method used to compute the confidence interval when
 #'  \code{ci = TRUE}. Either \code{"boot"} (default) for a percentile bootstrap,
@@ -107,6 +111,7 @@ NULL
 #' head(df)
 #'
 #' df %>% cohens_d(value ~ treatment, paired = TRUE)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/cohens-d-effect-size}{Cohen’s d Effect Size in R}.
 #'@export
 cohens_d <- function(data, formula, comparisons = NULL, ref.group = NULL, paired = FALSE, mu = 0,
                      var.equal = FALSE, hedges.correction = FALSE,

--- a/R/conover_test.R
+++ b/R/conover_test.R
@@ -17,6 +17,10 @@ NULL
 #'  \code{k - 1} comparisons (instead of all \code{k(k - 1)/2} pairwise
 #'  comparisons), exactly as for \code{\link{dunn_test}()}.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}
+#'  for a worked walkthrough.
+#'
 #'@inheritParams dunn_test
 #'@param ref.group a character string specifying the reference group. If
 #'  specified, for a given grouping variable, each of the group levels will be
@@ -61,6 +65,7 @@ NULL
 #'  Conover, W. J. and Iman, R. L. (1979) On multiple-comparisons procedures.
 #'  Technical Report LA-7677-MS, Los Alamos Scientific Laboratory.
 #' @seealso \code{\link{dunn_test}}, \code{\link{kruskal_test}}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}.
 #' @examples
 #' # Simple test
 #' ToothGrowth %>% conover_test(len ~ dose)

--- a/R/cor_as_symbols.R
+++ b/R/cor_as_symbols.R
@@ -4,6 +4,10 @@ NULL
 #'
 #' @description Take a correlation matrix and replace the correlation coefficients by symbols according to the
 #'   level of the correlation.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+#'  for a worked walkthrough.
 #' @param x a correlation matrix. Particularly, an object of class \code{cor_mat}.
 #' @param cutpoints numeric vector used for intervals. Default values are
 #'  \code{c(0, 0.25, 0.5, 0.75, 1)}.
@@ -11,6 +15,7 @@ NULL
 #'  correlation coefficient symbols. Default values are \code{c(" ", ".",  "+",
 #'  "*")}.
 #' @seealso \code{\link{cor_mat}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 #' @examples
 #' # Compute correlation matrix
 #' #::::::::::::::::::::::::::::::::::::::::::

--- a/R/cor_mark_significant.R
+++ b/R/cor_mark_significant.R
@@ -3,6 +3,10 @@ NULL
 #' Add Significance Levels To a Correlation Matrix
 #' @description Combines correlation coefficients and significance levels in a
 #'   correlation matrix data.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+#'  for a worked walkthrough.
 #' @inheritParams add_significance
 #' @param x an object of class \code{\link{cor_mat}()}.
 #' @return a data frame containing the lower triangular part of the correlation
@@ -12,6 +16,7 @@ NULL
 #'   select(mpg, disp, hp, drat, wt, qsec) %>%
 #'   cor_mat() %>%
 #'   cor_mark_significant()
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 #' @export
 cor_mark_significant <- function(x, cutpoints = c(0, 0.0001, 0.001, 0.01, 0.05,  1),
                                  symbols = c("****", "***", "**", "*",  ""))

--- a/R/cor_mat.R
+++ b/R/cor_mat.R
@@ -4,6 +4,10 @@ NULL
 #'@description Compute correlation matrix with p-values. Numeric columns in the
 #'  data are detected and automatically selected for the analysis. You can also
 #'  specify variables of interest to be used in the correlation analysis.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+#'  for a worked walkthrough.
 #'@inheritParams cor_test
 #'@param x an object of class \code{cor_mat}
 #'@param vars a character vector containing the variable names of interest.
@@ -14,6 +18,7 @@ NULL
 #'  \code{\link{cor_gather}()}, \code{\link{cor_select}()},
 #'  \code{\link{cor_as_symbols}()}, \code{\link{pull_triangle}()},
 #'  \code{\link{replace_triangle}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 #' @examples
 #' # Data preparation
 #' #:::::::::::::::::::::::::::::::::::::::::::

--- a/R/cor_plot.R
+++ b/R/cor_plot.R
@@ -11,6 +11,10 @@ NULL
 #'   The p-values contained in the outputs of the functions
 #'   \code{\link{cor_mat}()} and \code{rcorr()} are automatically detected and
 #'   used in the visualization.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+#'  for a worked walkthrough.
 #' @inheritParams corrplot::corrplot
 #' @param cor.mat the correlation matrix to visualize
 #' @param palette character vector containing the color palette.
@@ -29,6 +33,7 @@ NULL
 #'   = list(size = 1, color = "black", style = "bold")}.
 #' @param ... additional options not listed (i.e. "tl.cex") here to pass to corrplot.
 #' @seealso \code{\link{cor_as_symbols}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 #' @examples
 #' # Compute correlation matrix
 #' #::::::::::::::::::::::::::::::::::::::::::

--- a/R/cor_reorder.R
+++ b/R/cor_reorder.R
@@ -3,9 +3,14 @@ NULL
 #' Reorder Correlation Matrix
 #' @description reorder correlation matrix, according to the coefficients,
 #'   using the hierarchical clustering method.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+#'  for a worked walkthrough.
 #'@param x a correlation matrix. Particularly, an object of class \code{cor_mat}.
 #'@return a data frame
 #'@seealso \code{\link{cor_mat}()}, \code{\link{cor_gather}()}, \code{\link{cor_spread}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 #' @examples
 #' # Compute correlation matrix
 #' #::::::::::::::::::::::::::::::::::::::::::

--- a/R/cor_reshape.R
+++ b/R/cor_reshape.R
@@ -6,10 +6,15 @@ NULL
 #'   (long format). \item \code{cor_spread()}: spread a long correlation data format across
 #'   multiple columns. Particularly, it takes the results of \code{\link{cor_test}}
 #'   and transforms it into a correlation matrix. }
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+#'  for a worked walkthrough.
 #' @param data a data frame or matrix.
 #' @param drop.na logical. If TRUE, drop rows containing missing values after gathering the data.
 #' @param value column name containing the value to spread.
 #' @seealso \code{\link{cor_mat}()}, \code{\link{cor_reorder}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 #' @examples
 #' # Data preparation
 #' #::::::::::::::::::::::::::::::::::::::::::

--- a/R/cor_select.R
+++ b/R/cor_select.R
@@ -1,13 +1,19 @@
 #' @include utilities.R
 NULL
 #' Subset Correlation Matrix
+#'
+#' See the Datanovia tutorial
+#' \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+#' for a worked walkthrough.
 #' @name cor_select
 #' @param x a correlation matrix. Particularly, an object of class \code{cor_mat}.
 #' @param vars a character vector containing the variable names of interest.
 #' @param ... One or more unquoted expressions (or variable names) separated by
 #'  commas. Used to select variables of interest.
 #'@return a data frame
-#'@seealso \code{\link{cor_mat}()}, \code{\link{pull_triangle}()}, \code{\link{replace_triangle}()}
+#'@seealso \code{\link{cor_mat}()}, \code{\link{pull_triangle}()}, \code{\link{replace_triangle}()}.
+#'  The Datanovia tutorial:
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 #' @examples
 #' # Compute correlation matrix
 #' #::::::::::::::::::::::::::::::::::::::::::

--- a/R/cor_test.R
+++ b/R/cor_test.R
@@ -15,6 +15,10 @@ NULL
 #'  function, you can also compute, for example, the correlation between one
 #'  variable vs many.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r}{Correlation Test in R}
+#'  for a worked walkthrough.
+#'
 #'
 #'@inheritParams stats::cor.test
 #'@inheritParams stats::cor
@@ -53,6 +57,7 @@ NULL
 #'  TRUE)$cor}.
 #'@seealso \code{\link{cor_mat}()}, \code{\link{as_cor_mat}()},
 #'  \code{\link{rstatix-programming}} (using variable names held in strings)
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r}{Correlation Test in R}.
 #' @examples
 #'
 #' # Correlation between the specified variable vs

--- a/R/cramer_v.R
+++ b/R/cramer_v.R
@@ -4,6 +4,10 @@ NULL
 #'Compute Cramer's V
 #'@description Compute Cramer's V, which measures the strength of the
 #'  association between categorical variables.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r}{Chi-Square Test of Independence in R}
+#'  for a worked walkthrough.
 #'@inheritParams stats::chisq.test
 #'@param correct logical. If TRUE, Yates' continuity correction is applied when
 #'  computing the chi-square statistic, which only affects 2x2 tables. Default is
@@ -92,6 +96,7 @@ NULL
 #' cramer_v(tab)
 #' cramer_v(tab, correct = TRUE)
 #'
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r}{Chi-Square Test of Independence in R}.
 #'@export
 cramer_v <- function(x, y = NULL, correct = FALSE, ..., ci = FALSE, conf.level = 0.95) {
   test <- stats::chisq.test(x, y, correct = correct, ...)

--- a/R/dunn_test.R
+++ b/R/dunn_test.R
@@ -21,6 +21,10 @@ NULL
 #'  equivalent to filtering the full pairwise result afterwards, which would still
 #'  adjust over all pairs.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}
+#'  for a worked walkthrough.
+#'
 #'@inheritParams t_test
 #'@param ref.group a character string specifying the reference group. If
 #'  specified, for a given grouping variable, each of the group levels will be
@@ -70,6 +74,7 @@ NULL
 #' ToothGrowth %>%
 #'   group_by(supp) %>%
 #'   dunn_test(len ~ dose)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}.
 #'@export
 dunn_test <- function(data, formula, p.adjust.method = "holm", ref.group = NULL, detailed = FALSE,
                       effect.size = FALSE){

--- a/R/dunnett_test.R
+++ b/R/dunnett_test.R
@@ -15,6 +15,10 @@ NULL
 #'  \code{DescTools::DunnettTest()} and \code{multcomp::glht(..., mcp(... =
 #'  "Dunnett"))}.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+#'  for a worked walkthrough.
+#'
 #'@inheritParams t_test
 #'@param ref.group a character string specifying the reference (control) group.
 #'  Each remaining group level is compared against this group. If \code{NULL}
@@ -43,6 +47,7 @@ NULL
 #'  Association, 50, 1096-1121.
 #'@seealso \code{\link{tukey_hsd}()}, \code{\link{games_howell_test}()},
 #'  \code{\link{emmeans_test}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 #' @examples
 #' if (requireNamespace("emmeans", quietly = TRUE)) {
 #'

--- a/R/emmeans_test.R
+++ b/R/emmeans_test.R
@@ -8,6 +8,10 @@ NULL
 #'  contrast()} from the \code{emmeans} package, which need to be installed
 #'  before using this function. This function is useful for performing post-hoc
 #'  analyses following ANOVA/ANCOVA tests.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+#'  for a worked walkthrough.
 #'@inheritParams t_test
 #'@param model a fitted-model object such as the result of a call to
 #'  \code{lm()}, \code{stats::aov()} (including a within-subject \code{Error()}
@@ -77,6 +81,7 @@ NULL
 #' }
 #'
 #' }
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 #'@export
 emmeans_test <- function(data, formula, covariate = NULL, ref.group = NULL,
                          comparisons = NULL, p.adjust.method = "bonferroni",

--- a/R/eta_squared.R
+++ b/R/eta_squared.R
@@ -3,6 +3,10 @@ NULL
 #' Effect Size for ANOVA
 #' @description Compute eta-squared and partial eta-squared for all terms in an
 #'   ANOVA model.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+#'  for a worked walkthrough.
 #' @param model an object of class \code{aov} or \code{anova}.
 #' @param ci confidence level for a confidence interval on the effect size. If a
 #'   number between 0 and 1 (e.g. \code{0.95}), the function returns a tibble with
@@ -39,6 +43,7 @@ NULL
 #' # Effect size with confidence interval
 #' eta_squared(res.aov, ci = 0.95)
 #' partial_eta_squared(res.aov, ci = 0.95)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 
 #' @export
 eta_squared <- function(model, ci = NULL){

--- a/R/fisher_test.R
+++ b/R/fisher_test.R
@@ -8,6 +8,10 @@ NULL
 #'  have the advantage of performing pairwise and row-wise fisher tests, the
 #'  post-hoc tests following a significant chi-square test of homogeneity for 2xc
 #'  and rx2 contingency tables.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/categorical/fisher-exact-test-in-r}{Fisher’s Exact Test in R}
+#'  for a worked walkthrough.
 #'@inheritParams stats::fisher.test
 #'@param xtab a contingency table in a matrix form.
 #'@param p.adjust.method method to adjust p values for multiple comparisons.
@@ -107,6 +111,7 @@ NULL
 #'                              satisfaction = c("VeryD", "LittleD", "ModerateS", "VeryS")))
 #' fisher_test(Job)
 #' fisher_test(Job, simulate.p.value = TRUE, B = 1e5)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/fisher-exact-test-in-r}{Fisher’s Exact Test in R}.
 
 
 #' @describeIn fisher_test performs Fisher's exact test for testing the null of

--- a/R/fligner_test.R
+++ b/R/fligner_test.R
@@ -8,6 +8,10 @@ NULL
 #'  variances. It is robust against departures from normality and is a useful
 #'  alternative to \code{\link{levene_test}()}. Wrapper around the function
 #'  \code{\link[stats]{fligner.test}()}.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}
+#'  for a worked walkthrough.
 #'@param data a data.frame containing the variables in the formula.
 #'@param formula a formula of the form \code{x ~ group} where \code{x} is a
 #'  numeric variable giving the data values and \code{group} is a factor with
@@ -23,6 +27,7 @@ NULL
 #'  freedom. \item \code{p}: p-value. \item \code{method}: the statistical test
 #'  used to compare groups.}
 #'@seealso \code{\link{levene_test}}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}.
 #' @examples
 #' # Load data
 #' #:::::::::::::::::::::::::::::::::::::::

--- a/R/friedman_conover_test.R
+++ b/R/friedman_conover_test.R
@@ -17,6 +17,10 @@ NULL
 #'  and the p-value adjustment for multiple comparisons is computed over only
 #'  these \code{k - 1} comparisons (as for \code{\link{dunn_test}()}).
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}
+#'  for a worked walkthrough.
+#'
 #'@param data a data.frame containing the variables in the formula.
 #'@param formula a formula of the form \code{a ~ b | c}, where \code{a}
 #'  (numeric) is the dependent variable name; \code{b} is the within-subjects
@@ -68,6 +72,7 @@ NULL
 #'  edition. Wiley.
 #' @seealso \code{\link{friedman_test}}, \code{\link{friedman_nemenyi_test}},
 #'   \code{\link{friedman_effsize}}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}.
 #' @examples
 #' # A balanced complete block design: 3 treatments measured on 6 subjects
 #' df <- data.frame(

--- a/R/friedman_effsize.R
+++ b/R/friedman_effsize.R
@@ -17,6 +17,10 @@ NULL
 #'
 #'  Confidence intervals are calculated by bootstap.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}
+#'  for a worked walkthrough.
+#'
 #'@inheritParams friedman_test
 #'@inheritParams wilcox_effsize
 #'@param ... other arguments passed to the function \code{\link[stats]{friedman.test}()}
@@ -42,6 +46,7 @@ NULL
 #' # Friedman test effect size
 #' #:::::::::::::::::::::::::::::::::::::::::
 #' df %>% friedman_effsize(len ~ dose | id)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}.
 
 #' @export
 friedman_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,

--- a/R/friedman_nemenyi_test.R
+++ b/R/friedman_nemenyi_test.R
@@ -16,6 +16,10 @@ NULL
 #'  it does not borrow the residual rank variance and is therefore more
 #'  conservative.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}
+#'  for a worked walkthrough.
+#'
 #'@inheritParams friedman_conover_test
 #'@param detailed logical value. If TRUE, returns the rank-sum estimate and the
 #'  test method in the output.
@@ -52,6 +56,7 @@ NULL
 #'  Hollander, M., Wolfe, D. A. (1973) Nonparametric Statistical Methods. Wiley.
 #' @seealso \code{\link{friedman_test}}, \code{\link{friedman_conover_test}},
 #'   \code{\link{friedman_effsize}}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}.
 #' @examples
 #' # A balanced complete block design: 3 treatments measured on 6 subjects
 #' df <- data.frame(

--- a/R/friedman_test.R
+++ b/R/friedman_test.R
@@ -6,9 +6,11 @@ NULL
 #'@description Provides a pipe-friendly framework to perform a Friedman rank sum
 #'  test, which is the non-parametric alternative to the one-way repeated
 #'  measures ANOVA test. Wrapper around the function
-#'  \code{\link[stats]{friedman.test}()}. Read more:
-#'  \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman
-#'  test in R}.
+#'  \code{\link[stats]{friedman.test}()}.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}
+#'  for a worked walkthrough.
 #'@param data a data.frame containing the variables in the formula.
 #'@param formula a formula of the form \code{a ~ b | c}, where \code{a}
 #'  (numeric) is the dependent variable name; \code{b} is the within-subjects
@@ -37,6 +39,7 @@ NULL
 #' df %>% friedman_test(len ~ dose | id)
 #'
 #'@name friedman_test
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}.
 #'@export
 friedman_test <- function(data, formula, ...){
   args <- c(as.list(environment()), list(...)) %>%

--- a/R/games_howell_test.R
+++ b/R/games_howell_test.R
@@ -14,6 +14,10 @@ NULL
 #'  the multiple testing. So there is no need to apply additional p-value
 #'  corrections.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+#'  for a worked walkthrough.
+#'
 #'@param effect.size logical. Default is FALSE. If TRUE, a \code{cohens.d} column
 #'  and its \code{magnitude} are added. Because Games-Howell assumes unequal
 #'  variances, this is the Welch (averaged-variance) Cohen's d,
@@ -62,6 +66,7 @@ NULL
 #'   games_howell_test(len ~ dose)
 #'
 #'@rdname games_howell_test
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 #'@export
 games_howell_test <- function(data, formula, conf.level = 0.95, detailed = FALSE,
                               effect.size = FALSE){

--- a/R/get_pvalue_position.R
+++ b/R/get_pvalue_position.R
@@ -2,13 +2,13 @@
 NULL
 #'Autocompute P-value Positions For Plotting Significance
 #'@description Compute p-value x and y positions for plotting significance
-#'  levels. Many examples are provided at : \itemize{ \item
-#'  \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How
-#'   to Add P-Values onto a Grouped GGPLOT using the GGPUBR R Package} \item
-#'  \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{How
-#'   to Add Adjusted P-values to a Multi-Panel GGPlot} \item
-#'  \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How
-#'   to Add P-Values Generated Elsewhere to a GGPLOT} }
+#'  levels.
+#'
+#'  See the Datanovia tutorials
+#'  \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from Tests on ggplots in R (rstatix)}
+#'  and
+#'  \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{Auto P-values in ggplot with geom_pwc (ggpubr)}
+#'  for worked walkthroughs.
 #'@inheritParams t_test
 #'@param ref.group a character string specifying the reference group. If
 #'  specified, for a given grouping variable, each of the group levels will be
@@ -87,6 +87,7 @@ NULL
 #'      stat_pvalue_manual(stat.test, label = "p.adj.signif", tip.length = 0.01)
 #'   }
 #' }
+#' @seealso The Datanovia tutorials: \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from Tests on ggplots in R (rstatix)}, \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{Auto P-values in ggplot with geom_pwc (ggpubr)}.
 
 #'@describeIn get_pvalue_position compute the p-value y positions
 #'@export

--- a/R/get_summary_stats.R
+++ b/R/get_summary_stats.R
@@ -2,6 +2,10 @@
 NULL
 #'Compute Summary Statistics
 #'@description Compute summary statistics for one or multiple numeric variables.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r}{Descriptive Statistics in R}
+#'  for a worked walkthrough.
 #'@param data a data frame
 #'@param ... (optional) One or more unquoted expressions (or variable names)
 #'  separated by commas. Used to select a variable of interest. If no variable
@@ -38,6 +42,7 @@ NULL
 #'  m_4/m_2^2 - 3}. Skewness is \code{NA} for n < 3 and kurtosis for n < 4.
 #'@seealso \code{\link{rstatix-programming}} for selecting columns by names held
 #'  in strings (\code{!!}, \code{\{\{ \}\}}, \code{vars=}, \code{all_of()}).
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r}{Descriptive Statistics in R}.
 #' @examples
 #' # Full summary statistics
 #' data("ToothGrowth")

--- a/R/get_test_label.R
+++ b/R/get_test_label.R
@@ -4,6 +4,10 @@ NULL
 #' Extract Label Information from Statistical Tests
 #' @description Extracts label information from statistical tests. Useful for
 #'   labelling plots with test outputs.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from Tests on ggplots in R (rstatix)}
+#'  for a worked walkthrough.
 #' @param stat.test statistical test results returned by \code{rstatix}
 #'   functions.
 #' @param description the test description used as the prefix of the label.
@@ -123,6 +127,7 @@ NULL
 #'
 #'
 #' @describeIn get_test_label Extract label from pairwise comparisons.
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from Tests on ggplots in R (rstatix)}.
 #' @export
 get_pwc_label <- function(stat.test, type = c("expression", "text")){
   methods <- get_pairwise_comparison_methods()

--- a/R/kruskal_effesize.R
+++ b/R/kruskal_effesize.R
@@ -22,6 +22,10 @@ NULL
 #'
 #' Confidence intervals are calculated by bootstap.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}
+#'  for a worked walkthrough.
+#'
 #'@param method the effect-size metric. Either \code{"eta2"} (default) for the
 #'  bias-corrected eta-squared \code{eta2[H] = (H - k + 1)/(N - k)}, or
 #'  \code{"epsilon2"} for the rank epsilon-squared \code{H/(N - 1)} (Tomczak &
@@ -55,6 +59,7 @@ NULL
 #' df %>%
 #'   group_by(supp) %>%
 #'   kruskal_effsize(len ~ dose)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}.
 #' @export
 kruskal_effsize <- function(data, formula, ci = FALSE, conf.level = 0.95,  ci.type = "perc", nboot = 1000,
                             boot.parallel = getOption("boot.parallel", "no"),

--- a/R/kruskal_test.R
+++ b/R/kruskal_test.R
@@ -6,6 +6,10 @@ NULL
 #'@description Provides a pipe-friendly framework to perform Kruskal-Wallis
 #'  rank sum test. Wrapper around the function
 #'  \code{\link[stats]{kruskal.test}()}.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}
+#'  for a worked walkthrough.
 #'@param data a data.frame containing the variables in the formula.
 #'@param formula a formula of the form \code{x ~ group} where \code{x} is a
 #'  numeric variable giving the data values and \code{group} is a factor with
@@ -33,6 +37,7 @@ NULL
 #' df %>%
 #'   group_by(supp) %>%
 #'   kruskal_test(len ~ dose)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}.
 
 #'@name kruskal_test
 #'@export

--- a/R/ks_test.R
+++ b/R/ks_test.R
@@ -12,6 +12,10 @@ NULL
 #'  When the grouping factor contains more than two levels, pairwise
 #'  Kolmogorov-Smirnov tests are automatically performed, with p-value
 #'  adjustment.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}
+#'  for a worked walkthrough.
 #'@inheritParams stats::ks.test
 #'@param data a data.frame containing the variables in the formula.
 #'@param formula a formula of the form \code{x ~ group} where \code{x} is a
@@ -44,6 +48,7 @@ NULL
 #'  The \strong{returned object has an attribute called args}, which is a list
 #'  holding the test arguments.
 #'@seealso \code{\link{wilcox_test}()}, \code{\link{t_test}()}
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}.
 #' @examples
 #' # Two-samples test
 #' #:::::::::::::::::::::::::::::::::::::::::

--- a/R/levene_test.R
+++ b/R/levene_test.R
@@ -8,6 +8,10 @@ NULL
 #'
 #'   Wrapper around the function \code{\link[car]{leveneTest}()}, which can
 #'   additionally handles a grouped data.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}
+#'  for a worked walkthrough.
 #' @param data a data frame for evaluating the formula or a model
 #' @param formula a formula
 #' @param center The name of a function to compute the center of each group;
@@ -29,6 +33,7 @@ NULL
 #'   group_by(supp) %>%
 #'   levene_test(len ~ dose)
 #'
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}.
 #' @export
 levene_test <- function(data, formula, center = median){
   if(is_grouped_df(data)){

--- a/R/mahalanobis_distance.R
+++ b/R/mahalanobis_distance.R
@@ -22,6 +22,10 @@ NULL
 #'  function \code{qchisq(0.999, df) }, where df is the degree of freedom (i.e.,
 #'  the number of dependent variable used in the computation).
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}
+#'  for a worked walkthrough.
+#'
 #'@param data a data frame. Columns are variables.
 #'@param ... One unquoted expressions (or variable name). Used to select a
 #'  variable of interest. Can be also used to ignore a variable that are not
@@ -44,6 +48,7 @@ NULL
 #'  doo(~mahalanobis_distance(.)) %>%
 #'  filter(is.outlier == TRUE)
 #'
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}.
 #'@export
 mahalanobis_distance <- function(data, ...){
   if(is_grouped_df(data)){

--- a/R/mcnemar_test.R
+++ b/R/mcnemar_test.R
@@ -5,6 +5,10 @@ NULL
 #'
 #'  Wrappers around the R base function \code{\link[stats]{mcnemar.test}()}, but
 #'  provide pairwise comparisons between multiple groups
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/categorical/mcnemar-test-in-r}{McNemar’s Test in R}
+#'  for a worked walkthrough.
 #'@inheritParams stats::mcnemar.test
 #'@param data a data frame containing the variables in the formula.
 #'@param formula a formula of the form \code{a ~ b | c}, where \code{a} is the
@@ -74,6 +78,7 @@ NULL
 #'
 #'@describeIn mcnemar_test performs McNemar's chi-squared test for comparing two
 #'  paired proportions
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/mcnemar-test-in-r}{McNemar’s Test in R}.
 #'@export
 mcnemar_test <- function(x, y = NULL, correct = TRUE){
   args <- as.list(environment()) %>%

--- a/R/omega_squared.R
+++ b/R/omega_squared.R
@@ -6,6 +6,10 @@ NULL
 #'   for all terms in a between-subjects ANOVA model. Omega squared is a
 #'   less-biased alternative to eta squared, estimating the population effect
 #'   size rather than the sample one.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+#'  for a worked walkthrough.
 #' @param model an object of class \code{aov} or \code{anova} (a between-subjects
 #'   design). Repeated-measures and mixed models are not supported, as for
 #'   \code{\link{eta_squared}()}.
@@ -16,6 +20,7 @@ NULL
 #'   squared statistics: Measures of effect size for some common research
 #'   designs. \emph{Psychological Methods}, 8(4), 434-447.
 #' @seealso \code{\link{eta_squared}()}, \code{\link{anova_test}()}.
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 #' @examples
 #' # Data preparation
 #' df <- ToothGrowth

--- a/R/outliers.R
+++ b/R/outliers.R
@@ -21,6 +21,10 @@ NULL
 #'  even be ignored. Note that, any \code{NA} and \code{NaN} are automatically removed
 #'  before the quantiles are computed.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r}{Descriptive Statistics in R}
+#'  for a worked walkthrough.
+#'
 #'@return \itemize{ \item \code{identify_outliers()}. Returns the input data
 #'  frame with two additional columns: "is.outlier" and "is.extreme", which hold
 #'  logical values. \item \code{is_outlier() and is_extreme()}. Returns logical
@@ -53,6 +57,7 @@ NULL
 #' demo.data %>%
 #'   group_by(gender) %>%
 #'   identify_outliers("score")
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r}{Descriptive Statistics in R}.
 
 #'@describeIn outliers takes a data frame and extract rows suspected as outliers
 #'  according to a numeric column. The following columns are added "is.outlier"

--- a/R/posthoc_test.R
+++ b/R/posthoc_test.R
@@ -30,6 +30,10 @@ NULL
 #'   are not repeated. Choosing a test by first testing its assumptions on the
 #'   same data has a known cost --- see the note in \code{?check_test_assumptions}.
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions}{Statistical Tests and Assumptions in R}
+#'  for a worked walkthrough.
+#'
 #' @param data a data frame containing the variables in the formula.
 #' @param formula a formula of the form \code{x ~ group} where \code{x} is a
 #'   numeric outcome variable and \code{group} is a factor with two or more
@@ -51,6 +55,7 @@ NULL
 #' @seealso \code{\link{check_test_assumptions}()}, \code{\link{tukey_hsd}()}, \code{\link{games_howell_test}()},
 #'   \code{\link{dunn_test}()}, \code{\link{levene_test}()},
 #'   \code{\link{shapiro_test}()}.
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions}{Statistical Tests and Assumptions in R}.
 #'
 #' @examples
 #' df <- ToothGrowth

--- a/R/prop_test.R
+++ b/R/prop_test.R
@@ -9,6 +9,10 @@ NULL
 #'  the advantage of performing pairwise and row-wise z-test of two proportions,
 #'  the post-hoc tests following a significant chi-square test of homogeneity
 #'  for 2xc and rx2 contingency tables.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/proportion-z-tests-in-r}{Proportion Z-Test in R}
+#'  for a worked walkthrough.
 #'@inheritParams stats::prop.test
 #'@param xtab a cross-tabulation (or contingency table) with two columns and
 #'  multiple rows (rx2 design). The columns give the counts of successes and
@@ -114,6 +118,7 @@ NULL
 #' xtab
 #' # Compare the proportion of males and females in each category
 #' row_wise_prop_test(xtab)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/proportion-z-tests-in-r}{Proportion Z-Test in R}.
 
 
 #' @describeIn prop_test performs one-sample and two-samples z-test of

--- a/R/prop_trend_test.R
+++ b/R/prop_trend_test.R
@@ -6,6 +6,10 @@ NULL
 #'
 #'  Wrappers around the R base function \code{\link[stats]{prop.trend.test}()} but
 #'  returns a data frame for easy data visualization.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/categorical/cochran-armitage-trend-test-in-r}{Cochran-Armitage Trend Test in R}
+#'  for a worked walkthrough.
 #'@param xtab a cross-tabulation (or contingency table) with two columns and
 #'  multiple rows (rx2 design). The columns give the counts of successes and
 #'  failures respectively.
@@ -36,6 +40,7 @@ NULL
 #' xtab
 #' # Compare the proportion of survived between groups
 #' prop_trend_test(xtab)
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/cochran-armitage-trend-test-in-r}{Cochran-Armitage Trend Test in R}.
 
 #' @export
 prop_trend_test <- function(xtab, score = NULL){

--- a/R/shapiro_test.R
+++ b/R/shapiro_test.R
@@ -7,9 +7,11 @@ NULL
 #' @description Provides a pipe-friendly framework to performs Shapiro-Wilk test
 #'   of normality. Support grouped data and multiple variables for multivariate
 #'   normality tests. Wrapper around the R base function
-#'   \code{\link[stats]{shapiro.test}()}. Can handle grouped data. Read more:
-#'   \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality
-#'   Test in R}.
+#'   \code{\link[stats]{shapiro.test}()}. Can handle grouped data.
+#'
+#'   See the Datanovia tutorial
+#'   \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}
+#'   for a worked walkthrough.
 #' @param data a data frame. Columns are variables.
 #' @param ... One or more unquoted expressions (or variable names) separated by
 #'   commas. Used to select a variable of interest.
@@ -28,6 +30,7 @@ NULL
 #' # Multivariate normality test
 #' mshapiro_test(iris[, 1:3])
 #'
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}.
 
 #' @describeIn shapiro_test univariate Shapiro-Wilk normality test
 #' @export

--- a/R/sign_test.R
+++ b/R/sign_test.R
@@ -4,8 +4,11 @@
 NULL
 #'Sign Test
 #'
-#'@description Performs one-sample and two-sample sign tests. Read more:
-#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/sign-test-in-r}{Sign Test in R}.
+#'@description Performs one-sample and two-sample sign tests.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/sign-test-in-r}{Sign Test in R}
+#'  for a worked walkthrough.
 #'@inheritParams t_test
 #'@param data a data.frame containing the variables in the formula.
 #'@param formula a formula of the form \code{x ~ group} where \code{x} is a
@@ -80,6 +83,7 @@ NULL
 #'
 #'
 #'@describeIn sign_test Sign test
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/sign-test-in-r}{Sign Test in R}.
 #'@export
 sign_test <- function(data, formula, comparisons = NULL, ref.group = NULL,
                       p.adjust.method = "holm", alternative = "two.sided",

--- a/R/t_test.R
+++ b/R/t_test.R
@@ -4,7 +4,11 @@ NULL
 #'
 #'
 #'@description Provides a pipe-friendly framework to performs one and two sample
-#'  t-tests. Read more: \href{https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r}{T-test in R}.
+#'  t-tests.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r}{T-Test in R}
+#'  for a worked walkthrough.
 #'@inheritParams stats::t.test
 #'@param data a data.frame containing the variables in the formula.
 #'@param formula a formula of the form \code{x ~ group} where \code{x} is a
@@ -109,6 +113,7 @@ NULL
 #'  \code{mutate(statistic = -statistic, estimate = -estimate)}.
 #'@seealso \code{\link{rstatix-programming}} for building the formula from
 #'  variable names held in strings (e.g. \code{reformulate()}).
+#'   The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r}{T-Test in R}.
 #' @examples
 #' # Load data
 #' #:::::::::::::::::::::::::::::::::::::::

--- a/R/tukey_hsd.R
+++ b/R/tukey_hsd.R
@@ -11,6 +11,10 @@ NULL
 #'  essentially a t-test that corrects for multiple testing.
 #'
 #'  Can handle different inputs formats: aov, lm, formula.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+#'  for a worked walkthrough.
 #'@param x an object of class \code{aov}, \code{lm} or \code{data.frame}
 #'  containing the variables used in the formula.
 #'@param data a data.frame containing the variables in the formula.
@@ -50,6 +54,7 @@ NULL
 #'   group_by(supp) %>%
 #'   tukey_hsd(len ~ dose)
 #'
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 #'@export
 tukey_hsd <- function(x, ...){
   UseMethod("tukey_hsd", x)

--- a/R/utils-manova.R
+++ b/R/utils-manova.R
@@ -1,10 +1,13 @@
 #' Manova exported from car package
 #'
 #' See \code{car::\link[car:Anova]{Manova}} for details.
+#'  See the Datanovia tutorial \href{https://www.datanovia.com/learn/biostatistics/anova/manova-in-r}{MANOVA in R}
+#'  for a worked walkthrough.
 #'
 #' @name Manova
 #' @rdname Manova
 #' @keywords internal
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/manova-in-r}{MANOVA in R}.
 #' @export
 #' @importFrom car Manova
 NULL

--- a/R/welch_anova_test.R
+++ b/R/welch_anova_test.R
@@ -7,6 +7,10 @@ NULL
 #'   \code{\link[stats]{oneway.test}()}. This is is an alternative to the
 #'   standard one-way ANOVA in the situation where the homogeneity of variance
 #'   assumption is violated.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+#'  for a worked walkthrough.
 #' @param data a data frame containing the variables in the formula.
 #' @param formula a formula specifying the ANOVA model similar to aov. Can be of
 #'   the form y ~ group where y is a numeric variable giving the data values and
@@ -33,6 +37,7 @@ NULL
 #'   group_by(supp) %>%
 #'   welch_anova_test(len ~ dose)
 #' @name welch_anova_test
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 #' @export
 welch_anova_test <- function(data, formula){
   args <- as.list(environment()) %>%

--- a/R/wilcox_effsize.R
+++ b/R/wilcox_effsize.R
@@ -34,6 +34,10 @@ NULL
 #'  - < 0.3} (small effect), \code{0.30 - < 0.5} (moderate effect) and \code{>=
 #'  0.5} (large effect).
 #'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}
+#'  for a worked walkthrough.
+#'
 #'@inheritParams wilcox_test
 #'@param ci If TRUE, returns confidence intervals by bootstrap. May be slow.
 #'@param conf.level The level for the confidence interval.
@@ -104,6 +108,7 @@ NULL
 #'   wilcox_effsize(len ~ dose)
 #'
 #' }
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}.
 #'@export
 wilcox_effsize <- function(data, formula, comparisons = NULL, ref.group = NULL,
                                 paired = FALSE, alternative = "two.sided",

--- a/R/wilcox_test.R
+++ b/R/wilcox_test.R
@@ -5,9 +5,11 @@ NULL
 #'
 #'
 #'@description Provides a pipe-friendly framework to performs one and two sample
-#'  Wilcoxon tests. Read more:
-#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon in
-#'  R}.
+#'  Wilcoxon tests.
+#'
+#'  See the Datanovia tutorial
+#'  \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}
+#'  for a worked walkthrough.
 #'@inheritParams stats::wilcox.test
 #'@param data a data.frame containing the variables in the formula.
 #'@param formula a formula of the form \code{x ~ group} where \code{x} is a
@@ -167,6 +169,7 @@ NULL
 #' df %>% wilcox_test(len ~ dose, ref.group = "all")
 #'
 #'@describeIn wilcox_test Wilcoxon test
+#' @seealso The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}.
 #'@export
 wilcox_test <- function(
   data, formula, comparisons = NULL, ref.group = NULL,

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,6 +48,8 @@ It's also possible to compute several effect size metrics, including "eta square
 - `identify_outliers()`: Detect univariate outliers using boxplot methods. 
 - `mahalanobis_distance()`: Compute Mahalanobis Distance and Flag Multivariate Outliers.
 - `shapiro_test()` and `mshapiro_test()`: Univariate and multivariate Shapiro-Wilk normality test.
+
+Related tutorial: [Descriptive Statistics in R](https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r).
    
    
 ### Comparing means
@@ -63,12 +65,16 @@ It's also possible to compute several effect size metrics, including "eta square
 - `friedman_test()`: Provides a pipe-friendly framework to perform a Friedman rank sum test, which is the non-parametric alternative to the one-way repeated measures ANOVA test.
 - `get_comparisons()`: Create a list of possible pairwise comparisons between groups.
 - `add_xy_position()`, `get_y_position()`: autocompute p-value positions for plotting significance using ggplot2.
+
+Related tutorials: [T-Test in R](https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r) · [Wilcoxon Test in R](https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r).
    
    
 ### Facilitating ANOVA computation in R
    
 - `factorial_design()`: build factorial design for easily computing ANOVA using the `car::Anova()` function. This might be very useful for repeated measures ANOVA, which is hard to set up with the `car` package.
 - `anova_summary()`: Create beautiful summary tables of ANOVA test results obtained from either `car::Anova()` or `stats::aov()`. The results include ANOVA table, generalized effect size and some assumption checks, such as Mauchly's test for sphericity in the case of repeated measures ANOVA.
+
+Related tutorials: [One-Way ANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/anova-in-r) · [Repeated Measures ANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/repeated-measures-anova-in-r).
    
    
 ### Post-hoc analyses
@@ -82,6 +88,8 @@ It's also possible to compute several effect size metrics, including "eta square
 - `friedman_conover_test()` and `friedman_nemenyi_test()`: post-hoc pairwise comparisons (Conover and Nemenyi tests) following a significant Friedman test.
 - `games_howell_test()`: Performs Games-Howell test, which is used to compare all possible combinations of group differences when the assumption of homogeneity of variances is violated.
 - `emmeans_test()`: pipe-friendly wrapper arround `emmeans` function to perform pairwise comparisons of estimated marginal means. Useful for post-hoc analyses following up ANOVA/ANCOVA tests.
+
+Related tutorials: [One-Way ANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/anova-in-r) · [Kruskal-Wallis Test in R](https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r).
      
      
 ### Comparing proportions
@@ -94,6 +102,8 @@ It's also possible to compute several effect size metrics, including "eta square
 - `mcnemar_test()`: performs McNemar chi-squared test to compare paired proportions. Provides pairwise comparisons between multiple groups.
 - `cochran_qtest()`: extension of the McNemar Chi-squared test for comparing more than two paired proportions.
 - `prop_trend_test()`: Performs chi-squared test for trend in proportion. This test is also known as Cochran-Armitage trend test.
+
+Related tutorials: [Chi-Square Test of Independence in R](https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r) · [Proportion Z-Test in R](https://www.datanovia.com/learn/biostatistics/two-groups/proportion-z-tests-in-r) · [Fisher’s Exact Test in R](https://www.datanovia.com/learn/biostatistics/categorical/fisher-exact-test-in-r).
    
   
 ### Comparing variances
@@ -101,6 +111,8 @@ It's also possible to compute several effect size metrics, including "eta square
 - `levene_test()`: Pipe-friendly framework to easily compute Levene's test for homogeneity of variance across groups. Handles grouped data.
 - `fligner_test()`: Pipe-friendly wrapper around `stats::fligner.test()` to compute the Fligner-Killeen test, a non-parametric test for homogeneity of variances that is robust against departures from normality.
 - `box_m()`: Box's M-test for homogeneity of covariance matrices
+
+Related tutorial: [Homogeneity of Variance Test in R](https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r).
    
    
 ### Effect Size
@@ -113,6 +125,8 @@ It's also possible to compute several effect size metrics, including "eta square
 - `kruskal_effsize()`: Compute the effect size for Kruskal-Wallis test as the eta squared based on the H-statistic.
 - `friedman_effsize()`: Compute the effect size of Friedman test using the Kendall's W value.
 - `cramer_v()`: Compute Cramer's V, which measures the strength of the association between categorical variables, with optional confidence intervals.
+
+Related tutorial: [Cohen’s d Effect Size in R](https://www.datanovia.com/learn/biostatistics/two-groups/cohens-d-effect-size).
    
 ### Correlation analysis
    
@@ -143,6 +157,8 @@ It's also possible to compute several effect size metrics, including "eta square
 - `cor_as_symbols()`: replaces the correlation coefficients, in a matrix, by symbols according to the value.
 - `cor_plot()`: visualize correlation matrix using base plot.
 - `cor_mark_significant()`: add significance levels to a correlation matrix.
+
+Related tutorials: [Correlation Test in R](https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r) · [Correlation Matrix in R](https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r).
   
   
 ### Adjusting p-values, formatting and adding significance symbols
@@ -477,23 +493,38 @@ cor.mat %>%
     
 ## Related articles
 
-- [How to Add P-Values onto Basic GGPLOTS](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
-- [How to Add Adjusted P-values to a Multi-Panel GGPlot](https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values)
-- [How to Add P-values to GGPLOT Facets](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
-- [How to Add P-Values Generated Elsewhere to a GGPLOT](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
-- [How to Add P-Values onto a Grouped GGPLOT using the GGPUBR R Package](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
-- [How to Create Stacked Bar Plots with Error Bars and P-values](https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues)
-- [Add P-values and Significance Levels to ggplots](https://www.datanovia.com/learn/data-visualization/ggpubr/add-p-values)
-- [How to Add P-Values onto Horizontal GGPLOTS](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
-- [Comparing Means of Two Groups in R](https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r)
-    - [T-test in R](https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r)
+- Adding p-values to ggplots
+    - [P-values from Tests on ggplots in R (rstatix)](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
+    - [Auto P-values in ggplot with geom_pwc (ggpubr)](https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values)
+    - [Add P-values to ggplots in R (ggpubr)](https://www.datanovia.com/learn/data-visualization/ggpubr/add-p-values)
+    - [Stacked Bar Plot with Error Bars & P-values in R](https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues)
+- [Comparing Two Groups](https://www.datanovia.com/learn/biostatistics/two-groups/)
+    - [T-Test in R](https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r)
     - [Wilcoxon Test in R](https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r)
     - [Sign Test in R](https://www.datanovia.com/learn/biostatistics/two-groups/sign-test-in-r)
-- [Comparing Multiple Means in R](https://www.datanovia.com/learn/biostatistics/anova/)
-    - [ANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/anova-in-r)
+    - [Proportion Z-Test in R](https://www.datanovia.com/learn/biostatistics/two-groups/proportion-z-tests-in-r)
+- [The ANOVA Family](https://www.datanovia.com/learn/biostatistics/anova/)
+    - [One-Way ANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/anova-in-r)
     - [Repeated Measures ANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/repeated-measures-anova-in-r)
     - [Mixed ANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/mixed-anova-in-r)
     - [ANCOVA in R](https://www.datanovia.com/learn/biostatistics/anova/ancova-in-r)
-    - [One-Way MANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/manova-in-r)
+    - [MANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/manova-in-r)
     - [Kruskal-Wallis Test in R](https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r)
     - [Friedman Test in R](https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r)
+- Categorical data
+    - [Chi-Square Test of Independence in R](https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r)
+    - [Chi-Square Goodness-of-Fit Test in R](https://www.datanovia.com/learn/biostatistics/categorical/chi-square-goodness-of-fit-test-in-r)
+    - [Fisher’s Exact Test in R](https://www.datanovia.com/learn/biostatistics/categorical/fisher-exact-test-in-r)
+    - [McNemar’s Test in R](https://www.datanovia.com/learn/biostatistics/categorical/mcnemar-test-in-r)
+    - [Cochran’s Q Test in R](https://www.datanovia.com/learn/biostatistics/categorical/cochran-q-test-in-r)
+    - [Cochran-Armitage Trend Test in R](https://www.datanovia.com/learn/biostatistics/categorical/cochran-armitage-trend-test-in-r)
+- Correlation
+    - [Correlation Test in R](https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r)
+    - [Correlation Matrix in R](https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r)
+- Effect size
+    - [Cohen’s d Effect Size in R](https://www.datanovia.com/learn/biostatistics/two-groups/cohens-d-effect-size)
+- Assumptions and descriptives
+    - [Statistical Tests and Assumptions in R](https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions)
+    - [Normality Test in R](https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r)
+    - [Homogeneity of Variance Test in R](https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r)
+    - [Descriptive Statistics in R](https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Key functions
 -   `shapiro_test()` and `mshapiro_test()`: Univariate and multivariate
     Shapiro-Wilk normality test.
 
+Related tutorial: [Descriptive Statistics in
+R](https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r).
+
 ### Comparing means
 
 -   `t_test()`: perform one-sample, two-sample and pairwise t-tests
@@ -77,8 +80,13 @@ Key functions
     the one-way repeated measures ANOVA test.
 -   `get_comparisons()`: Create a list of possible pairwise comparisons
     between groups.
--   `add_xy_position()`, `get_y_position()`: autocompute p-value positions for plotting
-    significance using ggplot2.
+-   `add_xy_position()`, `get_y_position()`: autocompute p-value
+    positions for plotting significance using ggplot2.
+
+Related tutorials: [T-Test in
+R](https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r)
+· [Wilcoxon Test in
+R](https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r).
 
 ### Facilitating ANOVA computation in R
 
@@ -91,6 +99,11 @@ Key functions
     results include ANOVA table, generalized effect size and some
     assumption checks, such as Mauchly’s test for sphericity in the case
     of repeated measures ANOVA.
+
+Related tutorials: [One-Way ANOVA in
+R](https://www.datanovia.com/learn/biostatistics/anova/anova-in-r) ·
+[Repeated Measures ANOVA in
+R](https://www.datanovia.com/learn/biostatistics/anova/repeated-measures-anova-in-r).
 
 ### Post-hoc analyses
 
@@ -120,6 +133,11 @@ Key functions
 -   `emmeans_test()`: pipe-friendly wrapper arround `emmeans` function
     to perform pairwise comparisons of estimated marginal means. Useful
     for post-hoc analyses following up ANOVA/ANCOVA tests.
+
+Related tutorials: [One-Way ANOVA in
+R](https://www.datanovia.com/learn/biostatistics/anova/anova-in-r) ·
+[Kruskal-Wallis Test in
+R](https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r).
 
 ### Comparing proportions
 
@@ -154,6 +172,13 @@ Key functions
 -   `prop_trend_test()`: Performs chi-squared test for trend in
     proportion. This test is also known as Cochran-Armitage trend test.
 
+Related tutorials: [Chi-Square Test of Independence in
+R](https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r)
+· [Proportion Z-Test in
+R](https://www.datanovia.com/learn/biostatistics/two-groups/proportion-z-tests-in-r)
+· [Fisher’s Exact Test in
+R](https://www.datanovia.com/learn/biostatistics/categorical/fisher-exact-test-in-r).
+
 ### Comparing variances
 
 -   `levene_test()`: Pipe-friendly framework to easily compute Levene’s
@@ -164,6 +189,9 @@ Key functions
     non-parametric test for homogeneity of variances that is robust
     against departures from normality.
 -   `box_m()`: Box’s M-test for homogeneity of covariance matrices
+
+Related tutorial: [Homogeneity of Variance Test in
+R](https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r).
 
 ### Effect Size
 
@@ -183,6 +211,9 @@ Key functions
 -   `cramer_v()`: Compute Cramer’s V, which measures the strength of the
     association between categorical variables, with optional confidence
     intervals.
+
+Related tutorial: [Cohen’s d Effect Size in
+R](https://www.datanovia.com/learn/biostatistics/two-groups/cohens-d-effect-size).
 
 ### Correlation analysis
 
@@ -227,6 +258,11 @@ Key functions
 -   `cor_plot()`: visualize correlation matrix using base plot.
 -   `cor_mark_significant()`: add significance levels to a correlation
     matrix.
+
+Related tutorials: [Correlation Test in
+R](https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r)
+· [Correlation Matrix in
+R](https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r).
 
 ### Adjusting p-values, formatting and adding significance symbols
 
@@ -760,40 +796,68 @@ cor.mat %>%
 Related articles
 ----------------
 
--   [How to Add P-Values onto Basic
-    GGPLOTS](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
--   [How to Add Adjusted P-values to a Multi-Panel
-    GGPlot](https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values)
--   [How to Add P-values to GGPLOT
-    Facets](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
--   [How to Add P-Values Generated Elsewhere to a
-    GGPLOT](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
--   [How to Add P-Values onto a Grouped GGPLOT using the GGPUBR R
-    Package](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
--   [How to Create Stacked Bar Plots with Error Bars and
-    P-values](https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues)
--   [Add P-values and Significance Levels to
-    ggplots](https://www.datanovia.com/learn/data-visualization/ggpubr/add-p-values)
--   [How to Add P-Values onto Horizontal
-    GGPLOTS](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
--   [Comparing Means of Two Groups in
-    R](https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r)
-    -   [T-test in R](https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r)
+-   Adding p-values to ggplots
+    -   [P-values from Tests on ggplots in R
+        (rstatix)](https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests)
+    -   [Auto P-values in ggplot with geom\_pwc
+        (ggpubr)](https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values)
+    -   [Add P-values to ggplots in R
+        (ggpubr)](https://www.datanovia.com/learn/data-visualization/ggpubr/add-p-values)
+    -   [Stacked Bar Plot with Error Bars & P-values in
+        R](https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues)
+-   [Comparing Two
+    Groups](https://www.datanovia.com/learn/biostatistics/two-groups/)
+    -   [T-Test in
+        R](https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r)
     -   [Wilcoxon Test in
         R](https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r)
     -   [Sign Test in
         R](https://www.datanovia.com/learn/biostatistics/two-groups/sign-test-in-r)
--   [Comparing Multiple Means in
-    R](https://www.datanovia.com/learn/biostatistics/anova/)
-    -   [ANOVA in R](https://www.datanovia.com/learn/biostatistics/anova/anova-in-r)
+    -   [Proportion Z-Test in
+        R](https://www.datanovia.com/learn/biostatistics/two-groups/proportion-z-tests-in-r)
+-   [The ANOVA
+    Family](https://www.datanovia.com/learn/biostatistics/anova/)
+    -   [One-Way ANOVA in
+        R](https://www.datanovia.com/learn/biostatistics/anova/anova-in-r)
     -   [Repeated Measures ANOVA in
         R](https://www.datanovia.com/learn/biostatistics/anova/repeated-measures-anova-in-r)
     -   [Mixed ANOVA in
         R](https://www.datanovia.com/learn/biostatistics/anova/mixed-anova-in-r)
-    -   [ANCOVA in R](https://www.datanovia.com/learn/biostatistics/anova/ancova-in-r)
-    -   [One-Way MANOVA in
+    -   [ANCOVA in
+        R](https://www.datanovia.com/learn/biostatistics/anova/ancova-in-r)
+    -   [MANOVA in
         R](https://www.datanovia.com/learn/biostatistics/anova/manova-in-r)
     -   [Kruskal-Wallis Test in
         R](https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r)
     -   [Friedman Test in
         R](https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r)
+-   Categorical data
+    -   [Chi-Square Test of Independence in
+        R](https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r)
+    -   [Chi-Square Goodness-of-Fit Test in
+        R](https://www.datanovia.com/learn/biostatistics/categorical/chi-square-goodness-of-fit-test-in-r)
+    -   [Fisher’s Exact Test in
+        R](https://www.datanovia.com/learn/biostatistics/categorical/fisher-exact-test-in-r)
+    -   [McNemar’s Test in
+        R](https://www.datanovia.com/learn/biostatistics/categorical/mcnemar-test-in-r)
+    -   [Cochran’s Q Test in
+        R](https://www.datanovia.com/learn/biostatistics/categorical/cochran-q-test-in-r)
+    -   [Cochran-Armitage Trend Test in
+        R](https://www.datanovia.com/learn/biostatistics/categorical/cochran-armitage-trend-test-in-r)
+-   Correlation
+    -   [Correlation Test in
+        R](https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r)
+    -   [Correlation Matrix in
+        R](https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r)
+-   Effect size
+    -   [Cohen’s d Effect Size in
+        R](https://www.datanovia.com/learn/biostatistics/two-groups/cohens-d-effect-size)
+-   Assumptions and descriptives
+    -   [Statistical Tests and Assumptions in
+        R](https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions)
+    -   [Normality Test in
+        R](https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r)
+    -   [Homogeneity of Variance Test in
+        R](https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r)
+    -   [Descriptive Statistics in
+        R](https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r)

--- a/man/Manova.Rd
+++ b/man/Manova.Rd
@@ -5,5 +5,10 @@
 \title{Manova exported from car package}
 \description{
 See \code{car::\link[car:Anova]{Manova}} for details.
+ See the Datanovia tutorial \href{https://www.datanovia.com/learn/biostatistics/anova/manova-in-r}{MANOVA in R}
+ for a worked walkthrough.
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/manova-in-r}{MANOVA in R}.
 }
 \keyword{internal}

--- a/man/anova_summary.Rd
+++ b/man/anova_summary.Rd
@@ -76,6 +76,10 @@ Create beautiful summary tables of ANOVA test results obtained
 
  The results include ANOVA table, generalized effect size and some assumption
  checks.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+ for a worked walkthrough.
 }
 \examples{
 # Load data
@@ -115,6 +119,7 @@ anova_summary(res.anova)
 }
 \seealso{
 \code{\link{anova_test}()}, \code{\link{factorial_design}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 }
 \author{
 Alboukadel Kassambara, \email{alboukadel.kassambara@gmail.com}

--- a/man/anova_test.Rd
+++ b/man/anova_test.Rd
@@ -260,6 +260,7 @@ anova_test(.my.model)
 }
 \seealso{
 \code{\link{anova_summary}()}, \code{\link{factorial_design}()}
+  The Datanovia tutorials: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}, \href{https://www.datanovia.com/learn/biostatistics/anova/repeated-measures-anova-in-r}{Repeated Measures ANOVA in R}, \href{https://www.datanovia.com/learn/biostatistics/anova/mixed-anova-in-r}{Mixed ANOVA in R}, \href{https://www.datanovia.com/learn/biostatistics/anova/ancova-in-r}{ANCOVA in R}.
 }
 \author{
 Alboukadel Kassambara, \email{alboukadel.kassambara@gmail.com}

--- a/man/as_cor_mat.Rd
+++ b/man/as_cor_mat.Rd
@@ -17,6 +17,10 @@ Returns a data frame containing the matrix of the correlation
 \description{
 Convert a correlation test data frame, returned by the
   \code{\link{cor_test}()}, into a correlation matrix format.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+ for a worked walkthrough.
 }
 \examples{
 # Pairwise correlation tests between variables
@@ -33,4 +37,5 @@ res.cor.test \%>\% as_cor_mat()
 }
 \seealso{
 \code{\link{cor_mat}()}, \code{\link{cor_test}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 }

--- a/man/box_m.Rd
+++ b/man/box_m.Rd
@@ -24,8 +24,15 @@ A data frame containing the following components:
 Performs the Box's M-test for homogeneity of covariance matrices
   obtained from multivariate normal data according to one grouping variable.
   The test is based on the chi-square approximation.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}
+ for a worked walkthrough.
 }
 \examples{
 data(iris)
 box_m(iris[, -5], iris[, 5])
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}.
 }

--- a/man/check_test_assumptions.Rd
+++ b/man/check_test_assumptions.Rd
@@ -50,6 +50,10 @@ For a one-way, independent-groups design
   Games-Howell (which reduce to the classic result when variances are equal)
   or a rank-based test. Treat this recommendation as guidance, not a
   substitute for judgement.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions}{Statistical Tests and Assumptions in R}
+ for a worked walkthrough.
 }
 \examples{
 df <- ToothGrowth
@@ -59,4 +63,5 @@ df \%>\% check_test_assumptions(len ~ dose)
 \seealso{
 \code{\link{posthoc_test}()}, \code{\link{shapiro_test}()},
   \code{\link{levene_test}()}.
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions}{Statistical Tests and Assumptions in R}.
 }

--- a/man/chisq_test.Rd
+++ b/man/chisq_test.Rd
@@ -108,6 +108,10 @@ Performs chi-squared tests, including goodness-of-fit,
  table is built internally. Note that in the positional form the second column
  occupies the \code{correct} argument slot, so use the \code{vars} form (or the
  table interface) if you need to set \code{correct}/\code{simulate.p.value}.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r}{Chi-Square Test of Independence in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -174,4 +178,7 @@ df <- data.frame(
 df \%>\% chisq_test(gender, smoker)
 # Equivalent, using vars (keeps `correct` settable)
 df \%>\% chisq_test(vars = c("gender", "smoker"), correct = FALSE)
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r}{Chi-Square Test of Independence in R}, \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-goodness-of-fit-test-in-r}{Chi-Square Goodness-of-Fit Test in R}.
 }

--- a/man/cliff_delta.Rd
+++ b/man/cliff_delta.Rd
@@ -79,6 +79,10 @@ Compute Cliff's delta, a non-parametric effect size for the
   \eqn{\delta = (\#\{x > y\} - \#\{x < y\}) / (n_1 n_2)}. It ranges from
   \code{-1} to \code{1} and, unlike the rank-biserial \code{r}, is unaffected
   by ties beyond their contribution to the counts.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}
+ for a worked walkthrough.
 }
 \details{
 The magnitude thresholds are those of Romano et al. (2006):
@@ -106,4 +110,7 @@ Cliff, N. (1993). Dominance statistics: Ordinal analyses to answer ordinal
   Romano, J., Kromrey, J. D., Coraggio, J., & Skowronek, J. (2006). Appropriate
   statistics for ordinal level data. Annual meeting of the Florida Association
   of Institutional Research.
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}.
 }

--- a/man/cochran_qtest.Rd
+++ b/man/cochran_qtest.Rd
@@ -20,6 +20,10 @@ Performs the Cochran's Q test for unreplicated randomized block
  test is analogue to the \code{\link{friedman.test}()} with 0,1 coded
  response. It's an extension of the McNemar Chi-squared test for comparing
  more than two paired proportions.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/categorical/cochran-q-test-in-r}{Cochran’s Q Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Generate a demo data
@@ -41,4 +45,7 @@ cochran_qtest(mydata, outcome ~ treatment|participant)
 # pairwise comparisons between groups
 pairwise_mcnemar_test(mydata, outcome ~ treatment|participant)
 
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/cochran-q-test-in-r}{Cochran’s Q Test in R}.
 }

--- a/man/cohens_d.Rd
+++ b/man/cohens_d.Rd
@@ -135,6 +135,10 @@ Compute the effect size for t-test. T-test conventional effect
  It can also return confidence intervals for the effect size, either by
  bootstrap (the default) or by an analytic, deterministic method (see
  \code{ci.method}).
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/two-groups/cohens-d-effect-size}{Cohen’s d Effect Size in R}
+ for a worked walkthrough.
 }
 \details{
 Quantification of the effect size magnitude is performed using the
@@ -173,4 +177,7 @@ df \%>\% cohens_d(value ~ treatment, paired = TRUE)
  A primer on the understanding, use, and calculation of confidence intervals
  that are based on central and noncentral distributions. Educational and
  Psychological Measurement, 61(4), 532-574. }
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/cohens-d-effect-size}{Cohen’s d Effect Size in R}.
 }

--- a/man/conover_test.Rd
+++ b/man/conover_test.Rd
@@ -65,6 +65,10 @@ Performs Conover's test (also known as the Conover-Iman test) for
  the p-value adjustment for multiple comparisons is computed over only these
  \code{k - 1} comparisons (instead of all \code{k(k - 1)/2} pairwise
  comparisons), exactly as for \code{\link{dunn_test}()}.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}
+ for a worked walkthrough.
 }
 \details{
 The Conover-Iman pairwise statistic for comparing groups \eqn{i} and
@@ -108,4 +112,5 @@ Conover, W. J. (1999) Practical Nonparametric Statistics, 3rd
 }
 \seealso{
 \code{\link{dunn_test}}, \code{\link{kruskal_test}}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}.
 }

--- a/man/cor_as_symbols.Rd
+++ b/man/cor_as_symbols.Rd
@@ -23,6 +23,10 @@ correlation coefficient symbols. Default values are \code{c(" ", ".",  "+",
 \description{
 Take a correlation matrix and replace the correlation coefficients by symbols according to the
   level of the correlation.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+ for a worked walkthrough.
 }
 \examples{
 # Compute correlation matrix
@@ -40,4 +44,5 @@ cor.mat \%>\%
 }
 \seealso{
 \code{\link{cor_mat}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 }

--- a/man/cor_mark_significant.Rd
+++ b/man/cor_mark_significant.Rd
@@ -25,10 +25,17 @@ a data frame containing the lower triangular part of the correlation
 \description{
 Combines correlation coefficients and significance levels in a
   correlation matrix data.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+ for a worked walkthrough.
 }
 \examples{
 mtcars \%>\%
   select(mpg, disp, hp, drat, wt, qsec) \%>\%
   cor_mat() \%>\%
   cor_mark_significant()
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 }

--- a/man/cor_mat.Rd
+++ b/man/cor_mat.Rd
@@ -57,6 +57,10 @@ a data frame
 Compute correlation matrix with p-values. Numeric columns in the
  data are detected and automatically selected for the analysis. You can also
  specify variables of interest to be used in the correlation analysis.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -115,4 +119,5 @@ cor.mat \%>\% cor_gather()
  \code{\link{cor_gather}()}, \code{\link{cor_select}()},
  \code{\link{cor_as_symbols}()}, \code{\link{pull_triangle}()},
  \code{\link{replace_triangle}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 }

--- a/man/cor_plot.Rd
+++ b/man/cor_plot.Rd
@@ -68,6 +68,10 @@ Provide a tibble-friendly framework to visualize a correlation
   The p-values contained in the outputs of the functions
   \code{\link{cor_mat}()} and \code{rcorr()} are automatically detected and
   used in the visualization.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+ for a worked walkthrough.
 }
 \examples{
 # Compute correlation matrix
@@ -131,4 +135,5 @@ if(require("ggpubr")){
 }
 \seealso{
 \code{\link{cor_as_symbols}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 }

--- a/man/cor_reorder.Rd
+++ b/man/cor_reorder.Rd
@@ -15,6 +15,10 @@ a data frame
 \description{
 reorder correlation matrix, according to the coefficients,
   using the hierarchical clustering method.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+ for a worked walkthrough.
 }
 \examples{
 # Compute correlation matrix
@@ -36,4 +40,5 @@ cor.mat \%>\%
 }
 \seealso{
 \code{\link{cor_mat}()}, \code{\link{cor_gather}()}, \code{\link{cor_spread}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 }

--- a/man/cor_reshape.Rd
+++ b/man/cor_reshape.Rd
@@ -22,6 +22,10 @@ Reshape correlation analysis results. Key functions: \itemize{
   (long format). \item \code{cor_spread()}: spread a long correlation data format across
   multiple columns. Particularly, it takes the results of \code{\link{cor_test}}
   and transforms it into a correlation matrix. }
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -60,4 +64,5 @@ long.format \%>\% cor_spread(value = "p")
 }
 \seealso{
 \code{\link{cor_mat}()}, \code{\link{cor_reorder}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 }

--- a/man/cor_select.Rd
+++ b/man/cor_select.Rd
@@ -18,7 +18,9 @@ commas. Used to select variables of interest.}
 a data frame
 }
 \description{
-Subset Correlation Matrix
+See the Datanovia tutorial
+\href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}
+for a worked walkthrough.
 }
 \examples{
 # Compute correlation matrix
@@ -40,5 +42,7 @@ cor.mat \%>\%
 
 }
 \seealso{
-\code{\link{cor_mat}()}, \code{\link{pull_triangle}()}, \code{\link{replace_triangle}()}
+\code{\link{cor_mat}()}, \code{\link{pull_triangle}()}, \code{\link{replace_triangle}()}.
+ The Datanovia tutorial:
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation Matrix in R}.
 }

--- a/man/cor_test.Rd
+++ b/man/cor_test.Rd
@@ -77,6 +77,10 @@ Provides a pipe-friendly framework to perform correlation test
  two variables or between two different vectors of variables. Using this
  function, you can also compute, for example, the correlation between one
  variable vs many.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r}{Correlation Test in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -132,4 +136,5 @@ mtcars \%>\% cor_test(
 \seealso{
 \code{\link{cor_mat}()}, \code{\link{as_cor_mat}()},
  \code{\link{rstatix-programming}} (using variable names held in strings)
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r}{Correlation Test in R}.
 }

--- a/man/cramer_v.Rd
+++ b/man/cramer_v.Rd
@@ -42,6 +42,10 @@ By default, a single numeric value: Cramer's V.
 \description{
 Compute Cramer's V, which measures the strength of the
  association between categorical variables.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r}{Chi-Square Test of Independence in R}
+ for a worked walkthrough.
 }
 \details{
 Cramer's V is \eqn{V = \sqrt{\chi^2 / (N (k - 1))}} (Cramer, 1946),
@@ -114,4 +118,7 @@ Cramer, H. (1946). Mathematical Methods of Statistics. Princeton
  Steiger, J. H. (2004). Beyond the F test: Effect size confidence intervals
  and tests of close fit in the analysis of variance and contrast analysis.
  Psychological Methods, 9, 164-182.
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/chi-square-test-of-independence-in-r}{Chi-Square Test of Independence in R}.
 }

--- a/man/dunn_test.Rd
+++ b/man/dunn_test.Rd
@@ -76,6 +76,10 @@ Performs Dunn's test for pairwise multiple comparisons of the
  comparisons). Note that this affects the adjusted p-values: it is not
  equivalent to filtering the full pairwise result afterwards, which would still
  adjust over all pairs.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}
+ for a worked walkthrough.
 }
 \details{
 DunnTest performs the post hoc pairwise multiple comparisons
@@ -104,4 +108,7 @@ ToothGrowth \%>\%
 \references{
 Dunn, O. J. (1964) Multiple comparisons using rank sums
  Technometrics, 6(3):241-252.
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}.
 }

--- a/man/dunnett_test.Rd
+++ b/man/dunnett_test.Rd
@@ -62,6 +62,10 @@ Performs Dunnett's test for comparing each of several treatment
  \code{emmeans} package must be installed. The results match
  \code{DescTools::DunnettTest()} and \code{multcomp::glht(..., mcp(... =
  "Dunnett"))}.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+ for a worked walkthrough.
 }
 \examples{
 if (requireNamespace("emmeans", quietly = TRUE)) {
@@ -87,4 +91,5 @@ Dunnett, C. W. (1955) A multiple comparison procedure for comparing
 \seealso{
 \code{\link{tukey_hsd}()}, \code{\link{games_howell_test}()},
  \code{\link{emmeans_test}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 }

--- a/man/emmeans_test.Rd
+++ b/man/emmeans_test.Rd
@@ -87,6 +87,10 @@ Performs pairwise comparisons between groups using the estimated
  contrast()} from the \code{emmeans} package, which need to be installed
  before using this function. This function is useful for performing post-hoc
  analyses following ANOVA/ANCOVA tests.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -135,4 +139,7 @@ d \%>\% emmeans_test(score ~ time, model = rm_model)
 }
 
 }
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 }

--- a/man/eta_squared.Rd
+++ b/man/eta_squared.Rd
@@ -33,6 +33,10 @@ a named numeric vector of effect sizes, one per model term; or, when
 \description{
 Compute eta-squared and partial eta-squared for all terms in an
   ANOVA model.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -62,4 +66,7 @@ partial_eta_squared(res.aov, ci = 0.95)
 Steiger, J. H. (2004). Beyond the F test: Effect size confidence
   intervals and tests of close fit in the analysis of variance and contrast
   analysis. \emph{Psychological Methods}, 9, 164-182.
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 }

--- a/man/fisher_test.Rd
+++ b/man/fisher_test.Rd
@@ -86,6 +86,10 @@ Performs Fisher's exact test for testing the null of independence
  have the advantage of performing pairwise and row-wise fisher tests, the
  post-hoc tests following a significant chi-square test of homogeneity for 2xc
  and rx2 contingency tables.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/categorical/fisher-exact-test-in-r}{Fisher’s Exact Test in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -177,4 +181,7 @@ Job <- matrix(c(1,2,1,0, 3,3,6,1, 10,10,14,9, 6,7,12,11), 4, 4,
                              satisfaction = c("VeryD", "LittleD", "ModerateS", "VeryS")))
 fisher_test(Job)
 fisher_test(Job, simulate.p.value = TRUE, B = 1e5)
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/fisher-exact-test-in-r}{Fisher’s Exact Test in R}.
 }

--- a/man/fligner_test.Rd
+++ b/man/fligner_test.Rd
@@ -31,6 +31,10 @@ Provides a pipe-friendly framework to perform the Fligner-Killeen
  variances. It is robust against departures from normality and is a useful
  alternative to \code{\link{levene_test}()}. Wrapper around the function
  \code{\link[stats]{fligner.test}()}.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Load data
@@ -49,4 +53,5 @@ df \%>\%
 }
 \seealso{
 \code{\link{levene_test}}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}.
 }

--- a/man/friedman_conover_test.Rd
+++ b/man/friedman_conover_test.Rd
@@ -64,6 +64,10 @@ Performs Conover's all-pairs comparison test (also known as the
  remaining treatments is compared only to the reference (control) treatment,
  and the p-value adjustment for multiple comparisons is computed over only
  these \code{k - 1} comparisons (as for \code{\link{dunn_test}()}).
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}
+ for a worked walkthrough.
 }
 \details{
 For a balanced complete block design with \eqn{b} blocks and \eqn{k}
@@ -108,4 +112,5 @@ Conover, W. J. (1999) Practical Nonparametric Statistics, 3rd
 \seealso{
 \code{\link{friedman_test}}, \code{\link{friedman_nemenyi_test}},
   \code{\link{friedman_effsize}}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}.
 }

--- a/man/friedman_effsize.Rd
+++ b/man/friedman_effsize.Rd
@@ -68,6 +68,10 @@ Compute the effect size estimate (referred to as \code{w}) for
  effect)
 
  Confidence intervals are calculated by bootstap.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Load data
@@ -86,4 +90,7 @@ df \%>\% friedman_effsize(len ~ dose | id)
 Maciej Tomczak and Ewa Tomczak. The need to report effect size
  estimates revisited. An overview of some recommended measures of effect
  size. Trends in Sport Sciences. 2014; 1(21):19-25.
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}.
 }

--- a/man/friedman_nemenyi_test.Rd
+++ b/man/friedman_nemenyi_test.Rd
@@ -47,6 +47,10 @@ Performs the Nemenyi (Wilcoxon-Nemenyi-McDonald-Thompson) all-pairs
  HSD. Unlike \code{\link{friedman_conover_test}()} (the Durbin-Conover test),
  it does not borrow the residual rank variance and is therefore more
  conservative.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}
+ for a worked walkthrough.
 }
 \details{
 For a balanced complete block design with \eqn{b} blocks and \eqn{k}
@@ -85,4 +89,5 @@ Nemenyi, P. (1963) Distribution-free Multiple Comparisons. PhD
 \seealso{
 \code{\link{friedman_test}}, \code{\link{friedman_conover_test}},
   \code{\link{friedman_effsize}}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}.
 }

--- a/man/friedman_test.Rd
+++ b/man/friedman_test.Rd
@@ -28,9 +28,11 @@ return a data frame with the following columns: \itemize{ \item
 Provides a pipe-friendly framework to perform a Friedman rank sum
  test, which is the non-parametric alternative to the one-way repeated
  measures ANOVA test. Wrapper around the function
- \code{\link[stats]{friedman.test}()}. Read more:
- \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman
- test in R}.
+ \code{\link[stats]{friedman.test}()}.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Load data
@@ -45,4 +47,7 @@ head(df)
 #:::::::::::::::::::::::::::::::::::::::::
 df \%>\% friedman_test(len ~ dose | id)
 
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/friedman-test-in-r}{Friedman Test in R}.
 }

--- a/man/games_howell_test.Rd
+++ b/man/games_howell_test.Rd
@@ -57,6 +57,10 @@ Performs Games-Howell test, which is used to compare all possible
  the difference between each pair of means with appropriate adjustment for
  the multiple testing. So there is no need to apply additional p-value
  corrections.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+ for a worked walkthrough.
 }
 \details{
 The Games-Howell method is an improved version of the Tukey-Kramer
@@ -88,4 +92,7 @@ ToothGrowth \%>\%
  https://rpubs.com/aaronsc32/games-howell-test. \item Sangseok Lee, Dong Kyu
  Lee. What is the proper way to apply the multiple comparison test?. Korean J
  Anesthesiol. 2018;71(5):353-360. }
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 }

--- a/man/get_pvalue_position.Rd
+++ b/man/get_pvalue_position.Rd
@@ -125,13 +125,13 @@ when \code{x} specified.}
 }
 \description{
 Compute p-value x and y positions for plotting significance
- levels. Many examples are provided at : \itemize{ \item
- \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How
-  to Add P-Values onto a Grouped GGPLOT using the GGPUBR R Package} \item
- \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{How
-  to Add Adjusted P-values to a Multi-Panel GGPlot} \item
- \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How
-  to Add P-Values Generated Elsewhere to a GGPLOT} }
+ levels.
+
+ See the Datanovia tutorials
+ \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from Tests on ggplots in R (rstatix)}
+ and
+ \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{Auto P-values in ggplot with geom_pwc (ggpubr)}
+ for worked walkthroughs.
 }
 \section{Functions}{
 \itemize{
@@ -179,4 +179,7 @@ stat.test <- stat.test \%>\%
      stat_pvalue_manual(stat.test, label = "p.adj.signif", tip.length = 0.01)
   }
 }
+}
+\seealso{
+The Datanovia tutorials: \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from Tests on ggplots in R (rstatix)}, \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{Auto P-values in ggplot with geom_pwc (ggpubr)}.
 }

--- a/man/get_summary_stats.Rd
+++ b/man/get_summary_stats.Rd
@@ -59,6 +59,10 @@ A data frame containing descriptive statistics, such as: \itemize{
 }
 \description{
 Compute summary statistics for one or multiple numeric variables.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r}{Descriptive Statistics in R}
+ for a worked walkthrough.
 }
 \examples{
 # Full summary statistics
@@ -92,4 +96,5 @@ ToothGrowth \%>\%
 \seealso{
 \code{\link{rstatix-programming}} for selecting columns by names held
  in strings (\code{!!}, \code{\{\{ \}\}}, \code{vars=}, \code{all_of()}).
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r}{Descriptive Statistics in R}.
 }

--- a/man/get_test_label.Rd
+++ b/man/get_test_label.Rd
@@ -121,6 +121,10 @@ a text label or an expression to pass to a plotting function.
 \description{
 Extracts label information from statistical tests. Useful for
   labelling plots with test outputs.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from Tests on ggplots in R (rstatix)}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -200,4 +204,7 @@ get_description(stat.test)
 \references{
 American Psychological Association (2020). \emph{Publication Manual
   of the American Psychological Association} (7th ed.).
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from Tests on ggplots in R (rstatix)}.
 }

--- a/man/kruskal_effsize.Rd
+++ b/man/kruskal_effsize.Rd
@@ -77,6 +77,10 @@ Compute the effect size for Kruskal-Wallis test as the eta
  its valid \code{[0, 1]} range.
 
 Confidence intervals are calculated by bootstap.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Load data
@@ -101,4 +105,7 @@ Maciej Tomczak and Ewa Tomczak. The need to report effect size
  http://imaging.mrc-cbu.cam.ac.uk/statswiki/FAQ/effectSize
 
  http://www.psy.gla.ac.uk/~steve/best/effect.html
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}.
 }

--- a/man/kruskal_test.Rd
+++ b/man/kruskal_test.Rd
@@ -28,6 +28,10 @@ return a data frame with the following columns: \itemize{ \item
 Provides a pipe-friendly framework to perform Kruskal-Wallis
  rank sum test. Wrapper around the function
  \code{\link[stats]{kruskal.test}()}.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Load data
@@ -43,4 +47,7 @@ df \%>\% kruskal_test(len ~ dose)
 df \%>\%
   group_by(supp) \%>\%
   kruskal_test(len ~ dose)
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/kruskal-wallis-test-in-r}{Kruskal-Wallis Test in R}.
 }

--- a/man/ks_test.Rd
+++ b/man/ks_test.Rd
@@ -73,6 +73,10 @@ Provides a pipe-friendly framework to perform the two-sample
  When the grouping factor contains more than two levels, pairwise
  Kolmogorov-Smirnov tests are automatically performed, with p-value
  adjustment.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Two-samples test
@@ -89,4 +93,5 @@ ToothGrowth \%>\% ks_test(len ~ dose, ref.group = "0.5")
 }
 \seealso{
 \code{\link{wilcox_test}()}, \code{\link{t_test}()}
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}.
 }

--- a/man/levene_test.Rd
+++ b/man/levene_test.Rd
@@ -25,6 +25,10 @@ Provide a pipe-friendly framework to easily compute Levene's
 
   Wrapper around the function \code{\link[car]{leveneTest}()}, which can
   additionally handles a grouped data.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Prepare the data
@@ -39,4 +43,7 @@ df \%>\%
   group_by(supp) \%>\%
   levene_test(len ~ dose)
 
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/homogeneity-of-variance-in-r}{Homogeneity of Variance Test in R}.
 }

--- a/man/mahalanobis_distance.Rd
+++ b/man/mahalanobis_distance.Rd
@@ -39,6 +39,10 @@ Pipe-friendly wrapper around to the function
  The threshold to declare a multivariate outlier is determined using the
  function \code{qchisq(0.999, df) }, where df is the degree of freedom (i.e.,
  the number of dependent variable used in the computation).
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}
+ for a worked walkthrough.
 }
 \examples{
 
@@ -52,4 +56,7 @@ iris \%>\%
  doo(~mahalanobis_distance(.)) \%>\%
  filter(is.outlier == TRUE)
 
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}.
 }

--- a/man/mcnemar_test.Rd
+++ b/man/mcnemar_test.Rd
@@ -61,6 +61,10 @@ Performs McNemar chi-squared test to compare paired proportions.
 
  Wrappers around the R base function \code{\link[stats]{mcnemar.test}()}, but
  provide pairwise comparisons between multiple groups
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/categorical/mcnemar-test-in-r}{McNemar’s Test in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -109,4 +113,7 @@ cochran_qtest(mydata, outcome ~ treatment|participant)
 # pairwise comparisons between groups
 pairwise_mcnemar_test(mydata, outcome ~ treatment|participant)
 
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/mcnemar-test-in-r}{McNemar’s Test in R}.
 }

--- a/man/omega_squared.Rd
+++ b/man/omega_squared.Rd
@@ -24,6 +24,10 @@ Compute (classic, full) omega-squared and partial omega-squared
   for all terms in a between-subjects ANOVA model. Omega squared is a
   less-biased alternative to eta squared, estimating the population effect
   size rather than the sample one.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -51,4 +55,5 @@ Olejnik, S., & Algina, J. (2003). Generalized eta and omega
 }
 \seealso{
 \code{\link{eta_squared}()}, \code{\link{anova_test}()}.
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 }

--- a/man/outliers.Rd
+++ b/man/outliers.Rd
@@ -48,6 +48,10 @@ Detect outliers using boxplot methods. Boxplots are a popular and
  not considered as troublesome as those considered extreme points and might
  even be ignored. Note that, any \code{NA} and \code{NaN} are automatically removed
  before the quantiles are computed.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r}{Descriptive Statistics in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -78,4 +82,7 @@ demo.data \%>\%
 demo.data \%>\%
   group_by(gender) \%>\%
   identify_outliers("score")
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/descriptive-statistics-in-r}{Descriptive Statistics in R}.
 }

--- a/man/posthoc_test.Rd
+++ b/man/posthoc_test.Rd
@@ -84,6 +84,10 @@ Given a one-way, independent-groups design
   its result can be passed back here through \code{.assumptions} so the checks
   are not repeated. Choosing a test by first testing its assumptions on the
   same data has a known cost --- see the note in \code{?check_test_assumptions}.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions}{Statistical Tests and Assumptions in R}
+ for a worked walkthrough.
 }
 \examples{
 df <- ToothGrowth
@@ -96,4 +100,5 @@ df \%>\% posthoc_test(len ~ dose)
 \code{\link{check_test_assumptions}()}, \code{\link{tukey_hsd}()}, \code{\link{games_howell_test}()},
   \code{\link{dunn_test}()}, \code{\link{levene_test}()},
   \code{\link{shapiro_test}()}.
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/statistical-tests-and-assumptions}{Statistical Tests and Assumptions in R}.
 }

--- a/man/prop_test.Rd
+++ b/man/prop_test.Rd
@@ -93,6 +93,10 @@ Performs proportion tests to either evaluate the homogeneity of
  the advantage of performing pairwise and row-wise z-test of two proportions,
  the post-hoc tests following a significant chi-square test of homogeneity
  for 2xc and rx2 contingency tables.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/two-groups/proportion-z-tests-in-r}{Proportion Z-Test in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -179,4 +183,7 @@ dimnames(xtab) <- list(
 xtab
 # Compare the proportion of males and females in each category
 row_wise_prop_test(xtab)
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/proportion-z-tests-in-r}{Proportion Z-Test in R}.
 }

--- a/man/prop_trend_test.Rd
+++ b/man/prop_trend_test.Rd
@@ -31,6 +31,10 @@ Performs chi-squared test for trend in proportion. This test is
 
  Wrappers around the R base function \code{\link[stats]{prop.trend.test}()} but
  returns a data frame for easy data visualization.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/categorical/cochran-armitage-trend-test-in-r}{Cochran-Armitage Trend Test in R}
+ for a worked walkthrough.
 }
 \examples{
 # Proportion of renal stone (calculi) across age
@@ -47,4 +51,7 @@ dimnames(xtab) <- list(
 xtab
 # Compare the proportion of survived between groups
 prop_trend_test(xtab)
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/categorical/cochran-armitage-trend-test-in-r}{Cochran-Armitage Trend Test in R}.
 }

--- a/man/shapiro_test.Rd
+++ b/man/shapiro_test.Rd
@@ -26,9 +26,11 @@ a data frame containing the value of the Shapiro-Wilk statistic and
 Provides a pipe-friendly framework to performs Shapiro-Wilk test
   of normality. Support grouped data and multiple variables for multivariate
   normality tests. Wrapper around the R base function
-  \code{\link[stats]{shapiro.test}()}. Can handle grouped data. Read more:
-  \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality
-  Test in R}.
+  \code{\link[stats]{shapiro.test}()}. Can handle grouped data.
+
+  See the Datanovia tutorial
+  \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}
+  for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -50,4 +52,7 @@ iris \%>\% shapiro_test(Sepal.Length, Petal.Width)
 # Multivariate normality test
 mshapiro_test(iris[, 1:3])
 
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/assumptions/normality-test-in-r}{Normality Test in R}.
 }

--- a/man/sign_test.Rd
+++ b/man/sign_test.Rd
@@ -89,8 +89,11 @@ return a data frame with some the following columns: \itemize{ \item
  holding the test arguments.
 }
 \description{
-Performs one-sample and two-sample sign tests. Read more:
- \href{https://www.datanovia.com/learn/biostatistics/two-groups/sign-test-in-r}{Sign Test in R}.
+Performs one-sample and two-sample sign tests.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/two-groups/sign-test-in-r}{Sign Test in R}
+ for a worked walkthrough.
 }
 \section{Functions}{
 \itemize{
@@ -141,4 +144,7 @@ df \%>\% sign_test(len ~ dose)
 df \%>\% sign_test(len ~ dose, ref.group = "0.5")
 
 
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/sign-test-in-r}{Sign Test in R}.
 }

--- a/man/t_test.Rd
+++ b/man/t_test.Rd
@@ -145,7 +145,11 @@ return a data frame with some the following columns: \itemize{ \item
 }
 \description{
 Provides a pipe-friendly framework to performs one and two sample
- t-tests. Read more: \href{https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r}{T-test in R}.
+ t-tests.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r}{T-Test in R}
+ for a worked walkthrough.
 }
 \details{
 - If a list of comparisons is specified, the result of the pairwise tests is
@@ -220,4 +224,5 @@ df \%>\% t_test(len ~ dose, ref.group = "all")
 \seealso{
 \code{\link{rstatix-programming}} for building the formula from
  variable names held in strings (e.g. \code{reformulate()}).
+  The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/t-test-in-r}{T-Test in R}.
 }

--- a/man/tukey_hsd.Rd
+++ b/man/tukey_hsd.Rd
@@ -46,6 +46,10 @@ Provides a pipe-friendly framework to performs Tukey post-hoc
  essentially a t-test that corrects for multiple testing.
 
  Can handle different inputs formats: aov, lm, formula.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+ for a worked walkthrough.
 }
 \section{Methods (by class)}{
 \itemize{
@@ -79,4 +83,7 @@ df \%>\%
   group_by(supp) \%>\%
   tukey_hsd(len ~ dose)
 
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 }

--- a/man/welch_anova_test.Rd
+++ b/man/welch_anova_test.Rd
@@ -26,6 +26,10 @@ Tests for equal means in a one-way design (not assuming equal
   \code{\link[stats]{oneway.test}()}. This is is an alternative to the
   standard one-way ANOVA in the situation where the homogeneity of variance
   assumption is violated.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}
+ for a worked walkthrough.
 }
 \examples{
 # Load data
@@ -43,4 +47,7 @@ df \%>\% welch_anova_test(len ~ dose)
 df \%>\%
   group_by(supp) \%>\%
   welch_anova_test(len ~ dose)
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/anova/anova-in-r}{One-Way ANOVA in R}.
 }

--- a/man/wilcox_effsize.Rd
+++ b/man/wilcox_effsize.Rd
@@ -140,6 +140,10 @@ Compute Wilcoxon effect size (\code{r}) for: \itemize{ \item
  for r commonly in published litterature and on the internet are: \code{0.10
  - < 0.3} (small effect), \code{0.30 - < 0.5} (moderate effect) and \code{>=
  0.5} (large effect).
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}
+ for a worked walkthrough.
 }
 \examples{
 if(require("coin")){
@@ -168,4 +172,7 @@ ToothGrowth \%>\%
 Maciej Tomczak and Ewa Tomczak. The need to report effect size
  estimates revisited. An overview of some recommended measures of effect
  size. Trends in Sport Sciences. 2014; 1(21):19-25.
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}.
 }

--- a/man/wilcox_test.Rd
+++ b/man/wilcox_test.Rd
@@ -131,9 +131,11 @@ return a data frame with some of the following columns: \itemize{
 }
 \description{
 Provides a pipe-friendly framework to performs one and two sample
- Wilcoxon tests. Read more:
- \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon in
- R}.
+ Wilcoxon tests.
+
+ See the Datanovia tutorial
+ \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}
+ for a worked walkthrough.
 }
 \details{
 - \code{pairwise_wilcox_test()} applies the standard two sample
@@ -229,4 +231,7 @@ df \%>\% wilcox_test(len ~ dose, ref.group = "all")
 \references{
 Kerby, D. S. (2014). The simple difference formula: An approach to
  teaching nonparametric correlation. \emph{Comprehensive Psychology}, 3, 11.IT.3.1.
+}
+\seealso{
+The Datanovia tutorial: \href{https://www.datanovia.com/learn/biostatistics/two-groups/wilcoxon-test-in-r}{Wilcoxon Test in R}.
 }


### PR DESCRIPTION
Docs-only pass before the 1.1.0 submission: every test's help page now links the Datanovia lesson that teaches the method, and the README's tutorial links become a curated topical index. Refs #308.

## Help pages

Each relevant page closes its description with the lesson link and repeats it under See Also, so a reader landing on `?anova_test` or `?wilcox_test` goes straight to a worked walkthrough:

```r
?kruskal_test
#> Description: ... Wrapper around the function stats::kruskal.test().
#>   See the Datanovia tutorial "Kruskal-Wallis Test in R" for a worked walkthrough.
#> See Also: The Datanovia tutorial: "Kruskal-Wallis Test in R".
```

46 pages gain the link (effect sizes, ANOVA post-hoc, categorical tests, correlation helpers, assumptions, the APA label helpers); the 7 pages that already carried one keep it, normalized to the same placement and wording. Link texts are the lessons' titles as published. `binom_test()`/`multinom_test()` have no matching lesson and stay unlinked.

## README

- One `Related tutorial:` line per Key-functions section (three for proportions, which span genuinely distinct lessons).
- The Related-articles footer becomes a topical index: the five entries that all pointed at the same p-values page collapse to one, and grouped clusters are added for categorical tests, correlation, effect size and assumptions. Each URL now appears exactly once.

## Verification

Every URL was fetched at author time (browser user agent, full GET): HTTP 200, canonical, zero redirects, and each anchor matches the live page title. The R changes are comment-only (parse trees identical across the diff), function output is unchanged, and `R CMD check --as-cran` on the tarball is clean with no new NOTE — the CRAN URL check passes over all added links. NEWS records the change in one line.
