### PR TITLE
Open the 1.1.0.999 development cycle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rstatix
 Type: Package
 Title: Pipe-Friendly Framework for Basic Statistical Tests
-Version: 1.1.0
+Version: 1.1.0.999
 Date: 2026-07-23
 Authors@R: c(
     person("Alboukadel", "Kassambara", role = c("aut", "cre"), email = "alboukadel.kassambara@gmail.com"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# rstatix 1.1.0.999
+
+
 # rstatix 1.1.0
 
 ## New features


### PR DESCRIPTION
rstatix 1.1.0 was accepted on CRAN today. This moves master to the dev version and adds the next cycle's NEWS heading.