### PR TITLE
Label data subsets by their own group in df_split_by()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rstatix 1.1.0.999
 
+## Bug fixes
+
+- `df_split_by()`, `df_label_both()` and `df_label_value()` no longer attach another group's label to a subset (#324). The label was built by sorting the grouping variables and then writing the sorted labels back onto the unsorted rows, so any group whose position differed from its alphabetical rank got its neighbour's label — the wrong label also went into each nested subset. For example, `df_split_by(df, vars = "region")` on a character `region` running North, East, South returned North's data labelled `region:East`. Labels are now built row by row from each group's own values. `df_label_both()` was affected even when the grouping column was a factor, since the variable name is pasted onto the levels before the sort. The label's factor levels still follow the sorted order, so panel ordering is unchanged, and `df_unite_factors()` itself is untouched.
+
 
 # rstatix 1.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- `df_split_by()`, `df_label_both()` and `df_label_value()` no longer attach another group's label to a subset (#324). The label was built by sorting the grouping variables and then writing the sorted labels back onto the unsorted rows, so any group whose position differed from its alphabetical rank got its neighbour's label — the wrong label also went into each nested subset. For example, `df_split_by(df, vars = "region")` on a character `region` running North, East, South returned North's data labelled `region:East`. Labels are now built row by row from each group's own values. `df_label_both()` was affected even when the grouping column was a factor, since the variable name is pasted onto the levels before the sort. The label's factor levels still follow the sorted order, so panel ordering is unchanged, and `df_unite_factors()` itself is untouched.
+- `df_split_by()`, `df_label_both()` and `df_label_value()` no longer attach another group's label to a subset (#324). The label was built by sorting the grouping variables and then writing the sorted labels back onto the unsorted rows, so any group whose position differed from its sorted rank got its neighbour's label — the wrong label also went into each nested subset. For example, `df_split_by(df, vars = "region")` on a character `region` running North, East, South returned North's data labelled `region:East`. Labels are now built row by row from each group's own values. `df_label_both()` was affected even when the grouping column was a factor, since the variable name is pasted onto the levels before the sort. The label's factor levels still follow the sorted order, so panel ordering is unchanged, and `df_unite_factors()` itself is untouched.
 
 
 # rstatix 1.1.0

--- a/R/df.R
+++ b/R/df.R
@@ -220,8 +220,7 @@ df_label_both <- function(data, ..., vars = NULL, label_col = "label", sep = c("
   label <- data %>%
     df_select(vars = vars) %>%
     concat_groupname_to_levels(vars, sep = sep[2]) %>%
-    df_unite_factors(col = label_col, vars = vars, sep = sep[1]) %>%
-    pull(!!label_col)
+    unite_factors_in_place(col = label_col, vars = vars, sep = sep[1])
   data %>% mutate(!!label_col := label)
 }
 
@@ -232,8 +231,7 @@ df_label_value <- function(data, ..., vars = NULL, label_col = "label", sep = ",
   vars <- df_get_var_names(data, ..., vars = vars)
   label <- data %>%
     df_select(vars = vars) %>%
-    df_unite_factors(col = label_col, vars = vars, sep = sep[1]) %>%
-    pull(!!label_col)
+    unite_factors_in_place(col = label_col, vars = vars, sep = sep[1])
   data %>% mutate(!!label_col := label)
 }
 
@@ -244,9 +242,30 @@ add_panel_label <- function(data, groups, col = "label") {
   label <- data %>%
     df_select(vars = groups) %>%
     concat_groupname_to_levels(groups, sep = ":") %>%
-    df_unite_factors(col = col, vars = groups, sep = ", ") %>%
-    pull(!!col)
+    unite_factors_in_place(col = col, vars = groups, sep = ", ")
   data %>% mutate(!!col := label)
+}
+# Unite grouping columns into a labelling factor, one label per input row.
+#
+# Same output as pulling the united column out of df_unite_factors(), except
+# that the labels stay aligned with the rows they were built from:
+# df_unite_factors() sorts before uniting, so its column is a permutation of
+# the input rows and mutating it back onto the unsorted data mislabels every
+# row whose sorted position differs (#324). The factor levels are still taken
+# from the sorted order, so level order - and any downstream panel ordering
+# built on it - is unchanged.
+unite_factors_in_place <- function(data, col, vars, sep = "_"){
+  unite_and_pull <- function(x){
+    x %>%
+      df_unite(col = col, vars = vars, sep = sep) %>%
+      pull(!!col)
+  }
+  labels <- unite_and_pull(data)
+  levels <- data %>%
+    dplyr::arrange(!!!syms(vars)) %>%
+    unite_and_pull() %>%
+    unique()
+  factor(labels, levels = levels)
 }
 # Add a column containing panel name
 add_panel_name <- function(data, panel, col = "label") {

--- a/tests/testthat/test-df-labels.R
+++ b/tests/testthat/test-df-labels.R
@@ -1,0 +1,264 @@
+context("test-df-labels")
+
+# Regression tests for #324: df_label_both(), df_label_value() and
+# add_panel_label() built their label by pulling the united column out of
+# df_unite_factors(), which sorts its input before uniting, then mutated that
+# sorted vector back onto the unsorted data. Every row whose sorted position
+# differed from its own position got another group's label.
+#
+# The assertions below are deliberately row-by-row: comparing sorted sets, or
+# only the levels, cannot see a permutation of the values.
+
+# Label expected for one row, recomputed from that row's own key values.
+expected_both <- function(..., sep = c(", ", ":")) {
+  keys <- list(...)
+  paste(mapply(function(nm, v) paste(nm, v, sep = sep[2]), names(keys), keys),
+        collapse = sep[1])
+}
+
+test_that("df_split_by labels each subset with its own group, not a sorted neighbour (#324)", {
+  # region is character and not in alphabetical order, so nest order
+  # (North, East, South) differs from sorted order (East, North, South)
+  df <- data.frame(
+    region = rep(c("North", "East", "South"), each = 4),
+    value = 1:12,
+    stringsAsFactors = FALSE
+  )
+  res <- df_split_by(df, vars = "region")
+
+  expect_equal(as.character(res$region), c("North", "East", "South"))
+  expect_equal(
+    as.character(res$label),
+    c("region:North", "region:East", "region:South")
+  )
+  # row-by-row: the label must be built from that row's own key
+  for (i in seq_len(nrow(res))) {
+    expect_equal(as.character(res$label[i]), expected_both(region = res$region[i]))
+    # the subset really does hold that region's rows
+    expect_equal(res$data[[i]]$value, which(df$region == res$region[i]))
+  }
+
+  # add_panel_name() copies the label into every nested frame, so the same
+  # mislabelling reached the subsets themselves
+  for (i in seq_len(nrow(res))) {
+    expect_equal(
+      as.character(res$data[[i]]$label),
+      rep(expected_both(region = res$region[i]), nrow(res$data[[i]]))
+    )
+  }
+})
+
+test_that("df_label_both labels each row with its own key (#324)", {
+  df <- data.frame(
+    region = rep(c("North", "East", "South"), each = 4),
+    value = 1:12,
+    stringsAsFactors = FALSE
+  )
+
+  # on the nested keys
+  res <- df_nest_by(df, vars = "region") %>% df_label_both(vars = "region")
+  for (i in seq_len(nrow(res))) {
+    expect_equal(as.character(res$label[i]), expected_both(region = res$region[i]))
+  }
+
+  # and on an ordinary, unsorted data frame
+  res2 <- df_label_both(df, vars = "region")
+  expect_equal(as.character(res2$region), df$region)
+  for (i in seq_len(nrow(res2))) {
+    expect_equal(as.character(res2$label[i]), expected_both(region = res2$region[i]))
+  }
+})
+
+test_that("df_label_both on a factor follows the row, not the alphabet (#324)", {
+  # concat_groupname_to_levels() turns the factor into character before the
+  # unite, so the sort went alphabetical while nest order followed the levels:
+  # this misaligned even when the grouping column was a factor
+  df <- data.frame(
+    region = factor(rep(c("North", "East", "South"), each = 4),
+                    levels = c("North", "East", "South")),
+    value = 1:12
+  )
+  res <- df_nest_by(df, vars = "region") %>% df_label_both(vars = "region")
+
+  expect_equal(as.character(res$region), c("North", "East", "South"))
+  for (i in seq_len(nrow(res))) {
+    expect_equal(as.character(res$label[i]), expected_both(region = res$region[i]))
+  }
+})
+
+test_that("df_label_value labels each row with its own key (#324)", {
+  df <- data.frame(
+    region = rep(c("North", "East", "South"), each = 4),
+    value = 1:12,
+    stringsAsFactors = FALSE
+  )
+  res <- df_nest_by(df, vars = "region") %>% df_label_value(vars = "region")
+  for (i in seq_len(nrow(res))) {
+    expect_equal(as.character(res$label[i]), as.character(res$region[i]))
+  }
+
+  res2 <- df_split_by(df, vars = "region", labeller = df_label_value)
+  for (i in seq_len(nrow(res2))) {
+    expect_equal(as.character(res2$label[i]), as.character(res2$region[i]))
+  }
+})
+
+test_that("df_label_value on a factor with non-alphabetical levels is unchanged (#324)", {
+  # no-regression lock: arrange() on a factor follows its levels, which is
+  # already the nest order, so this path was correct before the fix and must
+  # stay byte-identical
+  df <- data.frame(
+    region = factor(rep(c("North", "East", "South"), each = 4),
+                    levels = c("North", "East", "South")),
+    value = 1:12
+  )
+  res <- df_nest_by(df, vars = "region") %>% df_label_value(vars = "region")
+
+  expect_equal(as.character(res$label), c("North", "East", "South"))
+  expect_equal(levels(res$label), c("North", "East", "South"))
+  for (i in seq_len(nrow(res))) {
+    expect_equal(as.character(res$label[i]), as.character(res$region[i]))
+  }
+})
+
+test_that("labelling handles multiple grouping variables (#324)", {
+  # ToothGrowth is ordered VC first, so the nest order (0.5/VC, 1/VC, 2/VC,
+  # 0.5/OJ, ...) differs from the sorted order (0.5/OJ, 0.5/VC, 1/OJ, ...)
+  res <- df_split_by(ToothGrowth, dose, supp)
+
+  expect_equal(nrow(res), 6)
+  for (i in seq_len(nrow(res))) {
+    expect_equal(
+      as.character(res$label[i]),
+      expected_both(dose = res$dose[i], supp = res$supp[i])
+    )
+    expect_equal(
+      res$data[[i]]$len,
+      ToothGrowth$len[ToothGrowth$dose == res$dose[i] & ToothGrowth$supp == res$supp[i]]
+    )
+  }
+
+  res2 <- df_label_value(df_nest_by(ToothGrowth, dose, supp), vars = c("dose", "supp"))
+  for (i in seq_len(nrow(res2))) {
+    expect_equal(
+      as.character(res2$label[i]),
+      paste(res2$dose[i], res2$supp[i], sep = ", ")
+    )
+  }
+})
+
+test_that("labelling is row-aligned when a value contains the separator (#324)", {
+  df <- data.frame(
+    g = c("b, x", "b, x", "a, y", "a, y"),
+    value = 1:4,
+    stringsAsFactors = FALSE
+  )
+  res <- df_split_by(df, vars = "g")
+
+  expect_equal(as.character(res$g), c("b, x", "a, y"))
+  for (i in seq_len(nrow(res))) {
+    expect_equal(as.character(res$label[i]), paste0("g:", res$g[i]))
+  }
+})
+
+test_that("labelling is row-aligned with NA in the grouping column (#324)", {
+  df <- data.frame(
+    g = c("North", "North", NA, NA, "East", "East"),
+    value = 1:6,
+    stringsAsFactors = FALSE
+  )
+  res <- df_split_by(df, vars = "g")
+
+  expect_equal(as.character(res$g), c("North", NA, "East"))
+  # unite() pastes a missing value as the string "NA"
+  expect_equal(as.character(res$label), c("g:North", "g:NA", "g:East"))
+  for (i in seq_len(nrow(res))) {
+    expect_equal(
+      as.character(res$label[i]),
+      paste0("g:", ifelse(is.na(res$g[i]), "NA", res$g[i]))
+    )
+  }
+
+  resv <- df_split_by(df, vars = "g", labeller = df_label_value)
+  expect_equal(as.character(resv$label), c("North", "NA", "East"))
+})
+
+test_that("labelling works with a single group (#324)", {
+  df <- data.frame(g = rep("only", 4), value = 1:4, stringsAsFactors = FALSE)
+  res <- df_split_by(df, vars = "g")
+
+  expect_equal(nrow(res), 1)
+  expect_equal(as.character(res$label), "g:only")
+  expect_equal(levels(res$label), "g:only")
+  expect_equal(as.character(res$data[[1]]$label), rep("g:only", 4))
+})
+
+test_that("add_panel_label labels each row with its own key (#324)", {
+  # internal helper, currently without a caller inside the package
+  df <- data.frame(
+    region = rep(c("North", "East", "South"), each = 4),
+    value = 1:12,
+    stringsAsFactors = FALSE
+  )
+  res <- add_panel_label(df_nest_by(df, vars = "region"), groups = "region")
+  for (i in seq_len(nrow(res))) {
+    expect_equal(as.character(res$label[i]), expected_both(region = res$region[i]))
+  }
+})
+
+test_that("label factor levels keep the order df_unite_factors() produces (#324)", {
+  # the fix moves which row gets which label; the level order - and so any
+  # downstream panel ordering built on it - must stay the sorted one
+  df <- data.frame(
+    region = rep(c("North", "East", "South"), each = 4),
+    value = 1:12,
+    stringsAsFactors = FALSE
+  )
+  nested <- df_nest_by(df, vars = "region")
+
+  both <- df_label_both(nested, vars = "region")
+  expect_s3_class(both$label, "factor")
+  expect_equal(levels(both$label), c("region:East", "region:North", "region:South"))
+
+  value <- df_label_value(nested, vars = "region")
+  expect_equal(levels(value$label), c("East", "North", "South"))
+
+  # parity with the exported uniting function the labellers used to borrow
+  expect_equal(
+    levels(value$label),
+    levels(df_unite_factors(nested, col = "label", vars = "region")$label)
+  )
+  expect_equal(
+    levels(df_split_by(ToothGrowth, dose, supp)$label),
+    levels(df_unite_factors(
+      concat_groupname_to_levels(df_select(df_nest_by(ToothGrowth, dose, supp),
+                                           vars = c("dose", "supp")),
+                                 c("dose", "supp"), sep = ":"),
+      col = "label", vars = c("dose", "supp"), sep = ", "
+    )$label)
+  )
+})
+
+test_that("df_unite_factors still sorts before uniting (#324)", {
+  # no-regression lock: df_unite_factors() is exported and documented as
+  # "First, order factors levels then merge"; the fix must not touch it
+  df <- data.frame(
+    region = rep(c("North", "East", "South"), each = 4),
+    value = 1:12,
+    stringsAsFactors = FALSE
+  )
+  res <- df_unite_factors(df, col = "label", vars = "region")
+
+  expect_equal(
+    as.character(res$label),
+    rep(c("East", "North", "South"), each = 4)
+  )
+  expect_equal(levels(res$label), c("East", "North", "South"))
+  expect_equal(res$value, c(5:8, 1:4, 9:12))
+
+  # and the untouched df_unite() keeps the input row order
+  expect_equal(
+    df_unite(df, col = "label", vars = "region")$label,
+    rep(c("North", "East", "South"), each = 4)
+  )
+})


### PR DESCRIPTION
`df_split_by(df, vars = "region")` on a character `region` running North, East,
South returns row 1 holding North's data labelled `region:East`, and row 2
holding East's data labelled `region:North`. The wrong label also goes into
each nested subset.

## What changed

`df_label_both()`, `df_label_value()` and the internal `add_panel_label()` built
their label by pulling the united column out of `df_unite_factors()`. That
function sorts its input before uniting, so the column it returns is a
permutation of the input rows; the labellers then mutated it back onto the
unsorted data. Every group whose position differed from its sorted rank got its
neighbour's label, and `add_panel_name()` copied that label into each nested
frame.

The three labellers now build the label on the original row order, through
`df_unite()`, and take the factor levels from the sorted order
`df_unite_factors()` would have produced. Only which row gets which label
changes.

`df_label_both()` was affected even when the grouping column was a factor:
`concat_groupname_to_levels()` pastes the variable name onto the levels first,
so the sort runs on the resulting character column while the nest order follows
the factor levels.

## User-facing effect

Labels now name the group whose rows they sit on. Level order is unchanged, so
panel ordering built on the label is unchanged, and `df_unite_factors()` itself
is untouched — it is exported and documented as ordering before it merges.

Data already in sorted order is unaffected. There is nothing to restore for
callers who want the old labels: they were a mis-pairing of subset and label,
not a setting. `df_arrange(vars = groups)` before `df_split_by()` returns the
subsets in sorted order, which is the same in both versions.

`add_panel_label()` is internal and has no caller in the package. It is fixed
rather than dropped, since it shares the new helper.

## Verification

- New `tests/testthat/test-df-labels.R` asserts row by row that each label is
  built from that row's own key: non-alphabetical character, `df_label_both()`
  on a factor, factor with non-alphabetical levels, multiple grouping variables,
  a value containing the separator, `NA` in the grouping column, a single group,
  plus locks on the level order and on `df_unite_factors()` still sorting.
  Every test was checked against a reintroduced defect.
- A before/after sweep over `df_unite_factors()`, `df_unite()` and the three
  labellers across ten fixtures shows no change to `df_unite_factors()` /
  `df_unite()`, and identical factor levels in every case where a label moved.

Fixes #324